### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -399,6 +399,18 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/privacy")
+def privacy():
+    """Privacy policy page."""
+    return render_template("privacy.html")
+
+
+@app.route("/terms")
+def terms():
+    """Terms of service page."""
+    return render_template("terms.html")
+
+
 @app.route("/auth/google")
 def auth_google():
     """Initiate Google OAuth flow."""

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Acquacotta</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 2rem;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            padding: 2rem;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid #667eea;
+        }
+        h2 {
+            color: #444;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+        }
+        p, li {
+            color: #555;
+            line-height: 1.7;
+            margin-bottom: 1rem;
+        }
+        ul {
+            margin-left: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        a {
+            color: #667eea;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 1.5rem;
+            color: #667eea;
+            font-weight: 500;
+        }
+        .updated {
+            color: #888;
+            font-size: 0.9rem;
+            margin-top: 2rem;
+            padding-top: 1rem;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="/" class="back-link">&larr; Back to Acquacotta</a>
+
+        <h1>Privacy Policy</h1>
+
+        <p>Acquacotta ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you use our Pomodoro time tracking application.</p>
+
+        <h2>Information We Collect</h2>
+        <p>When you use Acquacotta, we may collect:</p>
+        <ul>
+            <li><strong>Account Information:</strong> If you sign in with Google, we receive your email address, name, and profile picture from Google.</li>
+            <li><strong>Pomodoro Data:</strong> Time tracking entries you create, including task names, types, durations, timestamps, and notes.</li>
+            <li><strong>Settings:</strong> Your application preferences and configurations.</li>
+        </ul>
+
+        <h2>How We Use Your Information</h2>
+        <p>We use your information to:</p>
+        <ul>
+            <li>Provide and maintain the Acquacotta service</li>
+            <li>Sync your data across devices via Google Sheets (if you opt in)</li>
+            <li>Display your profile information within the app</li>
+            <li>Improve our service</li>
+        </ul>
+
+        <h2>Data Storage</h2>
+        <p>Your data is stored in two ways:</p>
+        <ul>
+            <li><strong>Local Storage:</strong> Pomodoro data is stored locally in a SQLite database on the server.</li>
+            <li><strong>Google Sheets:</strong> If you connect your Google account, your data is also synced to a Google Sheets spreadsheet in your own Google Drive. This spreadsheet is owned by you and subject to Google's privacy policies.</li>
+        </ul>
+
+        <h2>Third-Party Services</h2>
+        <p>Acquacotta uses the following third-party services:</p>
+        <ul>
+            <li><strong>Google OAuth:</strong> For authentication and Google Sheets integration</li>
+            <li><strong>Google Sheets API:</strong> For cloud data synchronization</li>
+            <li><strong>Google Drive API:</strong> To create and manage your Acquacotta spreadsheet</li>
+        </ul>
+        <p>These services are governed by <a href="https://policies.google.com/privacy" target="_blank">Google's Privacy Policy</a>.</p>
+
+        <h2>Data Sharing</h2>
+        <p>We do not sell, trade, or otherwise transfer your personal information to third parties. Your pomodoro data remains private to you.</p>
+
+        <h2>Data Security</h2>
+        <p>We implement reasonable security measures to protect your information. However, no method of transmission over the Internet is 100% secure.</p>
+
+        <h2>Your Rights</h2>
+        <p>You have the right to:</p>
+        <ul>
+            <li>Access your data at any time through the app</li>
+            <li>Export your data in CSV format</li>
+            <li>Delete your data by removing entries from the app</li>
+            <li>Disconnect your Google account at any time</li>
+        </ul>
+
+        <h2>Contact Us</h2>
+        <p>If you have questions about this Privacy Policy, please contact us through our <a href="https://github.com/fatherlinux/Acquacotta/issues" target="_blank">GitHub repository</a>.</p>
+
+        <h2>Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.</p>
+
+        <p class="updated">Last updated: December 2024</p>
+    </div>
+</body>
+</html>

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -123,7 +123,7 @@
         </ul>
 
         <h2>Contact Us</h2>
-        <p>If you have questions about this Privacy Policy, please contact us through our <a href="https://github.com/fatherlinux/Acquacotta/issues" target="_blank">GitHub repository</a>.</p>
+        <p>If you have questions about this Privacy Policy, please <a href="https://github.com/fatherlinux/Acquacotta/issues/new" target="_blank">open an issue on GitHub</a>.</p>
 
         <h2>Changes to This Policy</h2>
         <p>We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.</p>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - Acquacotta</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            padding: 2rem;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 16px;
+            padding: 2rem;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid #667eea;
+        }
+        h2 {
+            color: #444;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+        }
+        p, li {
+            color: #555;
+            line-height: 1.7;
+            margin-bottom: 1rem;
+        }
+        ul {
+            margin-left: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        a {
+            color: #667eea;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .back-link {
+            display: inline-block;
+            margin-bottom: 1.5rem;
+            color: #667eea;
+            font-weight: 500;
+        }
+        .updated {
+            color: #888;
+            font-size: 0.9rem;
+            margin-top: 2rem;
+            padding-top: 1rem;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="/" class="back-link">&larr; Back to Acquacotta</a>
+
+        <h1>Terms of Service</h1>
+
+        <p>Welcome to Acquacotta. By using our service, you agree to these terms. Please read them carefully.</p>
+
+        <h2>1. Acceptance of Terms</h2>
+        <p>By accessing or using Acquacotta, you agree to be bound by these Terms of Service and our <a href="/privacy">Privacy Policy</a>. If you do not agree to these terms, please do not use the service.</p>
+
+        <h2>2. Description of Service</h2>
+        <p>Acquacotta is a Pomodoro time tracking application that helps you manage your work sessions. The service allows you to:</p>
+        <ul>
+            <li>Track time spent on tasks using the Pomodoro Technique</li>
+            <li>Categorize and organize your work sessions</li>
+            <li>View reports and statistics about your productivity</li>
+            <li>Optionally sync your data to Google Sheets</li>
+        </ul>
+
+        <h2>3. User Accounts</h2>
+        <p>You may use Acquacotta without an account for local-only storage. If you choose to connect your Google account:</p>
+        <ul>
+            <li>You are responsible for maintaining the security of your Google account</li>
+            <li>You are responsible for all activities that occur through your connection</li>
+            <li>You must provide accurate information</li>
+        </ul>
+
+        <h2>4. Acceptable Use</h2>
+        <p>You agree not to:</p>
+        <ul>
+            <li>Use the service for any unlawful purpose</li>
+            <li>Attempt to gain unauthorized access to the service or its systems</li>
+            <li>Interfere with or disrupt the service</li>
+            <li>Use automated systems to access the service in a manner that exceeds reasonable use</li>
+        </ul>
+
+        <h2>5. Intellectual Property</h2>
+        <p>Acquacotta is open-source software. The source code is available under its respective license at <a href="https://github.com/fatherlinux/Acquacotta" target="_blank">GitHub</a>. Your data remains your own property.</p>
+
+        <h2>6. Data and Privacy</h2>
+        <p>Your use of the service is also governed by our <a href="/privacy">Privacy Policy</a>. By using Acquacotta, you consent to the collection and use of information as described in the Privacy Policy.</p>
+
+        <h2>7. Third-Party Services</h2>
+        <p>Acquacotta integrates with Google services. Your use of Google services is subject to Google's terms of service and privacy policy. We are not responsible for the practices of third-party services.</p>
+
+        <h2>8. Service Availability</h2>
+        <p>We strive to provide reliable service but do not guarantee:</p>
+        <ul>
+            <li>Uninterrupted or error-free operation</li>
+            <li>That defects will be corrected</li>
+            <li>That the service will meet your specific requirements</li>
+        </ul>
+
+        <h2>9. Disclaimer of Warranties</h2>
+        <p>THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. WE DISCLAIM ALL WARRANTIES INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.</p>
+
+        <h2>10. Limitation of Liability</h2>
+        <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE OF THE SERVICE.</p>
+
+        <h2>11. Changes to Terms</h2>
+        <p>We reserve the right to modify these terms at any time. We will notify users of significant changes by posting a notice on the service. Continued use after changes constitutes acceptance of the new terms.</p>
+
+        <h2>12. Termination</h2>
+        <p>You may stop using the service at any time. We reserve the right to suspend or terminate access to the service for violations of these terms.</p>
+
+        <h2>13. Contact</h2>
+        <p>For questions about these Terms of Service, please contact us through our <a href="https://github.com/fatherlinux/Acquacotta/issues" target="_blank">GitHub repository</a>.</p>
+
+        <p class="updated">Last updated: December 2024</p>
+    </div>
+</body>
+</html>

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -133,7 +133,7 @@
         <p>You may stop using the service at any time. We reserve the right to suspend or terminate access to the service for violations of these terms.</p>
 
         <h2>13. Contact</h2>
-        <p>For questions about these Terms of Service, please contact us through our <a href="https://github.com/fatherlinux/Acquacotta/issues" target="_blank">GitHub repository</a>.</p>
+        <p>For questions about these Terms of Service, please <a href="https://github.com/fatherlinux/Acquacotta/issues/new" target="_blank">open an issue on GitHub</a>.</p>
 
         <p class="updated">Last updated: December 2024</p>
     </div>


### PR DESCRIPTION
## Summary
Adds privacy policy and terms of service pages required for Google OAuth verification.

- Adds `/privacy` route with privacy policy content
- Adds `/terms` route with terms of service content
- Both pages styled to match the app's design

## URLs
Once deployed:
- https://acquacotta.crunchtools.com:8080/privacy
- https://acquacotta.crunchtools.com:8080/terms

## Google OAuth Verification Checklist
After merging:
1. [ ] Deploy updated container
2. [ ] Verify pages are accessible
3. [ ] Add privacy policy URL to Google Cloud Console
4. [ ] Add terms of service URL to Google Cloud Console  
5. [ ] Verify domain ownership in Google Search Console
6. [ ] Submit for Google OAuth verification review

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)