### PR TITLE
Add footer links to privacy policy and terms of service

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -677,6 +677,11 @@
             </div>
             <p style="color: var(--text-secondary); font-size: 0.75rem; text-align: center; margin-top: 1rem;">Settings are saved automatically</p>
         </div>
+
+        <footer style="text-align: center; padding: 2rem 0 1rem; margin-top: 2rem; border-top: 1px solid var(--border-color);">
+            <a href="/privacy" style="color: var(--text-secondary); font-size: 0.75rem; text-decoration: none; margin: 0 1rem;">Privacy Policy</a>
+            <a href="/terms" style="color: var(--text-secondary); font-size: 0.75rem; text-decoration: none; margin: 0 1rem;">Terms of Service</a>
+        </footer>
     </div>
 
     <!-- Add Manual Modal -->


### PR DESCRIPTION
## Summary
- Adds a footer section at the bottom of the main page
- Includes links to the Privacy Policy and Terms of Service pages
- Styled to match the existing UI with subtle secondary text styling

## Test plan
- [ ] Load the main page and scroll to the bottom
- [ ] Verify footer links appear below the Settings view
- [ ] Click Privacy Policy link and confirm it navigates to /privacy
- [ ] Click Terms of Service link and confirm it navigates to /terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)