### PR TITLE
Fix race condition when migrating pre-login pomodoros

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2962,6 +2962,12 @@
             // If logged in and needs initial sync, show sync options modal
             if (authStatus.logged_in && authStatus.needs_initial_sync) {
                 await showInitialSyncModal();
+            } else if (authStatus.logged_in) {
+                // Returning user - silently sync from Google Sheets in background
+                fetch('/api/sync/now', { method: 'POST' }).then(() => {
+                    loadWeeklyOverview();
+                    loadHistory();
+                }).catch(e => console.log('Background sync failed:', e));
             }
 
             // Always load settings (works with SQLite locally or Google Sheets when logged in)


### PR DESCRIPTION
## Summary
- Fix race condition where pre-login pomodoros were not offered for migration when logging into Google Sheets (Issue #10)
- `/api/sync/check` now returns `default_db_count` for pomodoros created before login
- `/api/migrate` supports new `default_to_sheets` direction to upload pre-login data
- Frontend prioritizes uploading pre-login data before pulling from Google Sheets

## Test plan
- [ ] Create pomodoros while not logged in
- [ ] Log in to Google Sheets
- [ ] Verify migration dialog shows pre-login pomodoro count and offers to upload
- [ ] Upload pre-login pomodoros and verify they appear in Google Sheets
- [ ] Verify local cache is populated after upload

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)