### PR TITLE
Switch to drive.file scope and fix batch sync rate limits

### DIFF
--- a/sheets_storage.py
+++ b/sheets_storage.py
@@ -60,6 +60,32 @@ def save_pomodoro(sheets_service, spreadsheet_id, pomodoro):
     ).execute()
 
 
+def save_pomodoros_batch(sheets_service, spreadsheet_id, pomodoros):
+    """Save multiple pomodoros to Google Sheets in a single request."""
+    if not pomodoros:
+        return
+
+    rows = []
+    for p in pomodoros:
+        rows.append([
+            p["id"],
+            p["name"],
+            p["type"],
+            p["start_time"],
+            p["end_time"],
+            p["duration_minutes"],
+            p.get("notes") or "",
+        ])
+
+    sheets_service.spreadsheets().values().append(
+        spreadsheetId=spreadsheet_id,
+        range="Pomodoros!A:G",
+        valueInputOption="RAW",
+        insertDataOption="INSERT_ROWS",
+        body={"values": rows},
+    ).execute()
+
+
 def update_pomodoro(sheets_service, spreadsheet_id, pomodoro_id, data):
     """Update a pomodoro in Google Sheets."""
     # Find the row with this ID

--- a/templates/index.html
+++ b/templates/index.html
@@ -363,6 +363,10 @@
 </head>
 <body>
     <div class="container">
+        <header style="text-align: center; padding: 1rem 0;">
+            <h1 style="font-size: 1.5rem; color: var(--text-primary); margin: 0;">Acquacotta</h1>
+            <p style="font-size: 0.875rem; color: var(--text-secondary); margin: 0.25rem 0 0 0;">Pomodoro Tracker</p>
+        </header>
         <nav>
             <button class="active" data-view="timer">Timer</button>
             <button data-view="reports">Reports</button>


### PR DESCRIPTION
## Summary
- Change OAuth scope from `spreadsheets` to `drive.file` (more limited, easier verification)
- Add `OAUTHLIB_RELAX_TOKEN_SCOPE` to handle scope changes gracefully
- Persist spreadsheet_id per user email to maintain access across sessions
- Use batch upload for pomodoro migration to avoid 60 req/min rate limit
- Add API error handler for better debugging
- Add app header to UI

Related to #7

## Test plan
- [ ] Log in with Google OAuth
- [ ] Verify spreadsheet is created with drive.file scope
- [ ] Test migration of 100+ pomodoros without rate limit errors
- [ ] Verify spreadsheet_id persists across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)