### PR TITLE
Add GitHub link to footer

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -969,6 +969,8 @@
 
     <footer style="text-align: center; padding: 0.25rem 0; margin: 0; color: var(--text-secondary); font-size: 0.625rem; line-height: 1;">
         <a href="https://www.youtube.com/watch?v=aQ_xKuXo0D0" target="_blank" rel="noopener" style="color: var(--text-secondary);">What is the Pomodoro Technique?</a>
+        <span style="margin: 0 0.5rem;">|</span>
+        <a href="https://github.com/fatherlinux/Acquacotta" target="_blank" rel="noopener" style="color: var(--text-secondary);">GitHub</a>
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- Adds a GitHub repository link to the footer, next to the Pomodoro Technique video link
- Uses consistent styling with the existing footer link

## Test plan
- [ ] Verify GitHub link appears in footer
- [ ] Click link and confirm it opens the repository in a new tab

Part of #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)