### PR TITLE
Auto-generate SSL certificates if not bind-mounted

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi:latest
 
-RUN dnf install -y python3.12 python3.12-pip httpd mod_ssl && dnf clean all
+RUN dnf install -y python3.12 python3.12-pip httpd mod_ssl openssl && dnf clean all
 
 WORKDIR /app
 

--- a/static/entrypoint.sh
+++ b/static/entrypoint.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 set -e
+
+# Auto-generate self-signed SSL certificates if not bind-mounted
+CERT_FILE="/etc/pki/tls/certs/origin.crt"
+KEY_FILE="/etc/pki/tls/private/origin.key"
+
+if [ ! -f "$CERT_FILE" ] || [ ! -f "$KEY_FILE" ]; then
+    echo "SSL certificates not found, generating self-signed certificates..."
+    mkdir -p /etc/pki/tls/certs /etc/pki/tls/private
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$KEY_FILE" \
+        -out "$CERT_FILE" \
+        -subj "/CN=localhost/O=Acquacotta/C=US" \
+        2>/dev/null
+    chmod 600 "$KEY_FILE"
+    echo "Self-signed SSL certificates generated."
+fi
+
 python3.12 /app/app.py &
 FLASK_PID=$!
 for i in {1..30}; do


### PR DESCRIPTION
## Summary
- Container now auto-generates self-signed SSL certificates at startup if none are provided
- Users can run the container immediately without configuring SSL first
- Production users can still bind-mount their own certificates

## Changes
- Modified `static/entrypoint.sh` to check for and generate certs
- Added `openssl` to Containerfile dependencies

## Test plan
- [ ] Build container: `podman build -t acquacotta .`
- [ ] Run without bind-mounting certs - verify it starts and generates self-signed certs
- [ ] Run with bind-mounted certs - verify it uses the provided certs
- [ ] Access https://localhost:443 - browser should warn about self-signed cert but allow access

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)