### PR TITLE
Switch to Gunicorn and add process supervision

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi10/ubi:latest
 
-RUN dnf install -y python3.12 python3.12-pip httpd mod_ssl openssl && dnf clean all
+RUN dnf install -y python3.12 python3.12-pip httpd mod_ssl openssl procps-ng && dnf clean all
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-session>=0.5
 google-auth>=2.0
 google-auth-oauthlib>=1.0
 google-api-python-client>=2.0
+gunicorn>=21.0

--- a/static/entrypoint.sh
+++ b/static/entrypoint.sh
@@ -17,15 +17,47 @@ if [ ! -f "$CERT_FILE" ] || [ ! -f "$KEY_FILE" ]; then
     echo "Self-signed SSL certificates generated."
 fi
 
-python3.12 /app/app.py &
-FLASK_PID=$!
-for i in {1..30}; do
-    if curl -s http://127.0.0.1:5000/ > /dev/null 2>&1; then
-        break
-    fi
-    sleep 1
-done
+# Start Flask with Gunicorn (production WSGI server)
+start_flask() {
+    gunicorn --bind 127.0.0.1:5000 --workers 2 --access-logfile - --error-logfile - app:app &
+    FLASK_PID=$!
+    echo "Gunicorn started with PID $FLASK_PID"
+}
+
+# Wait for Flask to be ready
+wait_for_flask() {
+    for i in {1..30}; do
+        if curl -s http://127.0.0.1:5000/ > /dev/null 2>&1; then
+            echo "Flask is ready"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Flask failed to start within 30 seconds"
+    return 1
+}
+
+# Flask supervisor loop - restarts Flask if it exits
+supervise_flask() {
+    while true; do
+        if ! kill -0 $FLASK_PID 2>/dev/null; then
+            echo "Flask (PID $FLASK_PID) exited, restarting..."
+            start_flask
+            sleep 2  # Brief delay before checking readiness
+        fi
+        sleep 5  # Check every 5 seconds
+    done
+}
+
+start_flask
+wait_for_flask
+
+# Start Flask supervisor in background
+supervise_flask &
+SUPERVISOR_PID=$!
+
 cleanup() {
+    kill $SUPERVISOR_PID 2>/dev/null || true
     kill $FLASK_PID 2>/dev/null || true
     exit 0
 }


### PR DESCRIPTION
## Summary

- Replace Flask's dev server with Gunicorn (production WSGI server with 2 workers)
- Add supervisor loop to automatically restart Gunicorn if it crashes
- Add `procps-ng` package for diagnostic tools (`ps`, `top`, etc.)

## Background

Flask crashed in production but Apache kept running, requiring a full container restart. The root cause was using Flask's built-in Werkzeug dev server, which is single-threaded and not designed for production.

## Changes

| File | Change |
|------|--------|
| `requirements.txt` | Add `gunicorn>=21.0` |
| `Containerfile` | Add `procps-ng` for diagnostic tools |
| `static/entrypoint.sh` | Use Gunicorn + add supervisor loop |

## Test plan

- [ ] Build container locally and verify Gunicorn starts
- [ ] Verify `ps` command is available inside container
- [ ] Kill Gunicorn process and verify it auto-restarts

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)