### PR TITLE
Fix race condition in cache clearing with multiple Gunicorn workers

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,8 +65,8 @@ DEFAULT_DB_PATH = DATA_DIR / "pomodoros.db"  # For non-logged-in users
 
 # Clear cache on startup (default: true for development, set to "false" in production)
 CLEAR_CACHE_ON_START = os.environ.get("CLEAR_CACHE_ON_START", "true").lower() == "true"
-if CLEAR_CACHE_ON_START and DEFAULT_DB_PATH.exists():
-    DEFAULT_DB_PATH.unlink()
+if CLEAR_CACHE_ON_START:
+    DEFAULT_DB_PATH.unlink(missing_ok=True)
     print(f"Cleared cache: {DEFAULT_DB_PATH}")
 
 DEFAULT_POMODORO_TYPES = [


### PR DESCRIPTION
## Summary

Fix `FileNotFoundError` when multiple Gunicorn workers start simultaneously and both try to clear the cache DB.

## Problem

With the switch to Gunicorn (#47), multiple workers start at the same time. Both workers could pass the `exists()` check before either deletes the file:

1. Worker 1: `DEFAULT_DB_PATH.exists()` → True
2. Worker 2: `DEFAULT_DB_PATH.exists()` → True
3. Worker 1: `unlink()` → succeeds
4. Worker 2: `unlink()` → `FileNotFoundError`

## Fix

Use `missing_ok=True` in the `unlink()` call, making the operation idempotent.

```python
# Before
if CLEAR_CACHE_ON_START and DEFAULT_DB_PATH.exists():
    DEFAULT_DB_PATH.unlink()

# After
if CLEAR_CACHE_ON_START:
    DEFAULT_DB_PATH.unlink(missing_ok=True)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)