### PR TITLE
Fix week view block layout for short and long descriptions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -317,11 +317,10 @@
             position: relative;
             cursor: pointer;
             display: flex;
-            align-items: center;
             white-space: nowrap;
         }
         .week-pomo-name {
-            flex: 1;
+            flex: 0 1 auto;
             min-width: 0;
             overflow: hidden;
         }


### PR DESCRIPTION
## Summary
Follow-up fix to PR #50. The previous fix caused a gap between short names and the count (e.g., "AI      : 2").

This fix uses `flex: 0 1 auto` instead of `flex: 1` so:
- Short names like "AI: 2" appear without a gap
- Long names truncate (hard cut, no ellipsis) while keeping the count visible

## Test plan
- [x] Tested locally with short descriptions (AI, etc.)
- [x] Tested locally with long descriptions (Roots of The Valley, etc.)
- [ ] Verify in production after merge

Fixes issue from #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)