### PR TITLE
Add stricter linting configuration per Gourmand recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,10 @@ Thumbs.db
 # App data
 *.db
 
+# Linting/Tools
+.gourmand-cache/
+.ruff_cache/
+.pytest_cache/
+
 # Other
 start.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,10 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+        stages: [pre-commit, pre-merge-commit]
       - id: ruff-format
         args: [--check]
+        stages: [pre-commit, pre-merge-commit]
 
   # Run Python tests (local hook)
   - repo: local
@@ -35,4 +37,4 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-        stages: [commit]
+        stages: [pre-commit, pre-merge-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,24 @@ select = [
     "B",      # flake8-bugbear
     "C4",     # flake8-comprehensions
     "UP",     # pyupgrade
+    "C901",   # McCabe complexity
+    "PLR",    # Pylint refactor rules
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
     "B008",   # do not perform function calls in argument defaults
     "B904",   # allow raise without from in except
 ]
+
+[tool.ruff.lint.pylint]
+max-branches = 10
+max-statements = 50
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["PLR2004"]  # Magic values acceptable in test assertions
 
 [tool.ruff.lint.isort]
 known-first-party = ["app", "sheets_storage"]


### PR DESCRIPTION
## Summary
- Add C901 (McCabe complexity) and PLR (Pylint refactor) rules to ruff
- Add pylint thresholds: max-branches=10, max-statements=50
- Add mccabe max-complexity=10  
- Add `pre-merge-commit` stage to ruff hooks (prevents bypass via fast-forward merge)
- Ignore PLR2004 in tests (magic values acceptable in test assertions)
- Add `.gourmand-cache/`, `.ruff_cache/`, `.pytest_cache/` to .gitignore

These changes address the `linter_configuration` violations from [Gourmand](https://codeberg.org/mattdm/gourmand), an AI slop detection tool.

## Test plan
- [x] All 41 pytest tests pass
- [x] `ruff check .` passes with no violations
- [x] Gourmand `linter_configuration` check now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)