### PR TITLE
Add multi-layer container architecture for faster CI/CD

### DIFF
--- a/.github/workflows/container-base.yml
+++ b/.github/workflows/container-base.yml
@@ -1,0 +1,86 @@
+name: Build Base Container Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Containerfile.base'
+      - 'Containerfile.test'
+      - 'requirements.txt'
+      - 'requirements-dev.txt'
+      - 'static/acquacotta-http.conf'
+      - 'static/entrypoint.sh'
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+  BASE_IMAGE: fatherlinux/acquacotta-base
+  TEST_IMAGE: fatherlinux/acquacotta-test
+
+jobs:
+  build-base:
+    name: Build Base Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile.base
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:latest
+            ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:buildcache,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  build-test:
+    name: Build Test Image
+    runs-on: ubuntu-latest
+    needs: build-base
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push test image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile.test
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.TEST_IMAGE }}:latest
+            ${{ env.REGISTRY }}/${{ env.TEST_IMAGE }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.TEST_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.TEST_IMAGE }}:buildcache,mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,27 +1,17 @@
-FROM registry.access.redhat.com/ubi10/ubi:latest
+# Production image for Acquacotta
+# Built on top of acquacotta-base - only contains app code
+# Very fast to build since infrastructure is pre-cached
+#
+# Build: podman build -t quay.io/fatherlinux/acquacotta .
 
-RUN dnf install -y python3.12 python3.12-pip httpd procps-ng && dnf clean all
+FROM quay.io/fatherlinux/acquacotta-base:latest
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip3.12 install --no-cache-dir -r requirements.txt
-
+# Copy only application code (fast)
 COPY app.py .
 COPY sheets_storage.py .
 COPY templates/ templates/
 COPY static/ static/
-
-# Apache HTTP reverse proxy configuration (SSL handled by external reverse proxy)
-COPY static/acquacotta-http.conf /etc/httpd/conf.d/acquacotta.conf
-RUN rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/welcome.conf
-
-# Entrypoint script
-COPY static/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
-
-ENV FLASK_HOST=127.0.0.1
-
-EXPOSE 80
 
 CMD ["/entrypoint.sh"]

--- a/Containerfile.base
+++ b/Containerfile.base
@@ -1,0 +1,28 @@
+# Base image for Acquacotta
+# Contains slow-to-install infrastructure: RPMs, Python packages, Apache config
+# Rebuild only when dependencies change
+#
+# Build: podman build -f Containerfile.base -t quay.io/fatherlinux/acquacotta-base .
+
+FROM registry.access.redhat.com/ubi10/ubi:latest
+
+# Install system packages (slow)
+RUN dnf install -y python3.12 python3.12-pip httpd procps-ng && dnf clean all
+
+WORKDIR /app
+
+# Install Python production dependencies (slow)
+COPY requirements.txt .
+RUN pip3.12 install --no-cache-dir -r requirements.txt
+
+# Apache HTTP reverse proxy configuration (SSL handled by external reverse proxy)
+COPY static/acquacotta-http.conf /etc/httpd/conf.d/acquacotta.conf
+RUN rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/welcome.conf
+
+# Entrypoint script
+COPY static/entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
+ENV FLASK_HOST=127.0.0.1
+
+EXPOSE 80

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -1,0 +1,48 @@
+# Test image for Acquacotta
+# Built on top of acquacotta-base - includes all test frameworks
+# Used by CI/CD for running tests quickly
+#
+# Build: podman build -f Containerfile.test -t quay.io/fatherlinux/acquacotta-test .
+
+FROM quay.io/fatherlinux/acquacotta-base:latest
+
+# Install Node.js for JavaScript tests (Puppeteer)
+RUN dnf install -y nodejs npm && dnf clean all
+
+# Install Rust for Gourmand
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install Gourmand from Codeberg
+RUN cargo install --git https://codeberg.org/mattdm/gourmand.git
+
+# Install Python dev/test dependencies
+COPY requirements-dev.txt .
+RUN pip3.12 install --no-cache-dir -r requirements-dev.txt
+
+# Install Puppeteer for JS tests
+RUN npm install -g puppeteer
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+RUN dnf install -y chromium && dnf clean all
+
+WORKDIR /app
+
+# Copy application code
+COPY app.py .
+COPY sheets_storage.py .
+COPY templates/ templates/
+COPY static/ static/
+
+# Copy test code and config
+COPY tests/ tests/
+COPY pyproject.toml .
+COPY gourmand.toml .
+COPY gourmand-exceptions.toml .
+
+# Set test environment
+ENV FLASK_SECRET_KEY=test-secret-key
+ENV CLEAR_CACHE_ON_START=false
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Default command runs all tests
+CMD ["sh", "-c", "ruff check . && ruff format --check . && pytest tests/ -v && gourmand --full ."]


### PR DESCRIPTION
## Summary
Three-layer container strategy to dramatically speed up CI/CD:

1. **acquacotta-base** - Infrastructure layer (RPMs, Python deps, Apache)
2. **acquacotta** - App layer (just code, very fast to build)
3. **acquacotta-test** - Test layer (pytest, ruff, Node, Rust, Gourmand)

## New Files
- `Containerfile.base` - Base image with slow-to-install infrastructure
- `Containerfile.test` - Test image with all test frameworks pre-installed
- `.github/workflows/container-base.yml` - Builds base/test images when deps change

## Modified
- `Containerfile` - Now builds FROM acquacotta-base (much faster)

## Architecture
```
ubi10 → acquacotta-base → acquacotta (production)
                        → acquacotta-test (CI/CD)
```

## Benefits
- Release builds only copy app code (~seconds vs ~minutes)
- Base image only rebuilds when dependencies change
- Test image has all frameworks pre-installed for future CI optimization

## Next Steps After Merge
1. Manually trigger `container-base.yml` to build initial base images
2. Future release builds will use the pre-built base

🤖 Generated with [Claude Code](https://claude.com/claude-code)