### PR TITLE
Treat 404 on delete as success in sync

### DIFF
--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -467,7 +467,8 @@
                     const res = await authenticatedFetch(`/api/sheets/pomodoros/${record_id}`, {
                         method: 'DELETE'
                     });
-                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                    // 404 on delete is OK - record already doesn't exist
+                    if (!res.ok && res.status !== 404) throw new Error(`HTTP ${res.status}`);
                 }
             } else if (store === 'settings') {
                 const res = await authenticatedFetch('/api/sheets/settings', {


### PR DESCRIPTION
## Summary
Fixes sync error when deleting pomodoros that were never synced to Google Sheets.

## Problem
When a pomodoro is created locally but never synced (e.g., during 502 errors), deleting it would fail with a 404 error because the record doesn't exist in Google Sheets.

## Solution
Treat HTTP 404 on DELETE as success - the record is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)