### PR TITLE
fix: redirect to fresh OAuth when session is cleared mid-flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -336,15 +336,16 @@ def auth_google():
 def auth_callback():
     """Handle Google OAuth callback."""
     try:
-        # Validate OAuth state to prevent CSRF attacks
+        # Validate OAuth state and PKCE verifier — both must be present from the initial auth request.
+        # If either is missing the session was cleared (browser restart, cookie expiry) mid-flow;
+        # the stale authorization code is unusable so restart cleanly.
         callback_state = request.args.get("state")
         stored_state = session.pop("oauth_state", None)  # Pop to ensure one-time use
+        code_verifier = session.pop("code_verifier", None)
 
-        if stored_state is None:
-            # Session was cleared (browser restart, cookie expiry) while OAuth was in flight.
-            # The authorization code is now unusable — restart the flow cleanly.
-            app.logger.info("OAuth callback: session missing (browser restart/expiry), restarting OAuth flow")
-            return redirect(url_for("auth_google"))
+        if stored_state is None or code_verifier is None:
+            app.logger.info("OAuth callback: session cleared mid-flow (browser restart/expiry), restarting OAuth flow")
+            return redirect("/auth/google")
 
         if not callback_state or callback_state != stored_state:
             app.logger.warning("OAuth state mismatch - possible CSRF attack")
@@ -354,17 +355,8 @@ def auth_callback():
         if not flow:
             return jsonify({"error": "Google OAuth not configured"}), HTTPStatus.INTERNAL_SERVER_ERROR
 
-        # Restore PKCE code_verifier from the initial auth request
-        code_verifier = session.pop("code_verifier", None)
-        if code_verifier is None:
-            # code_verifier missing despite a valid state — PKCE handshake is broken.
-            # Restart the flow; the stale authorization code can't be exchanged anyway.
-            app.logger.warning("OAuth callback: code_verifier missing despite valid state, restarting OAuth flow")
-            return redirect(url_for("auth_google"))
         flow.code_verifier = code_verifier
-        app.logger.info(
-            f"OAuth callback: Retrieved code_verifier from session (length: {len(code_verifier)})"
-        )
+        app.logger.info(f"OAuth callback: Retrieved code_verifier from session (length: {len(code_verifier)})")
         app.logger.info(f"OAuth callback: Session keys present: {list(session.keys())}")
         flow.fetch_token(authorization_response=request.url)
         credentials = flow.credentials

--- a/app.py
+++ b/app.py
@@ -339,6 +339,13 @@ def auth_callback():
         # Validate OAuth state to prevent CSRF attacks
         callback_state = request.args.get("state")
         stored_state = session.pop("oauth_state", None)  # Pop to ensure one-time use
+
+        if stored_state is None:
+            # Session was cleared (browser restart, cookie expiry) while OAuth was in flight.
+            # The authorization code is now unusable — restart the flow cleanly.
+            app.logger.info("OAuth callback: session missing (browser restart/expiry), restarting OAuth flow")
+            return redirect(url_for("auth_google"))
+
         if not callback_state or callback_state != stored_state:
             app.logger.warning("OAuth state mismatch - possible CSRF attack")
             return jsonify({"error": "Invalid OAuth state"}), HTTPStatus.BAD_REQUEST
@@ -348,9 +355,15 @@ def auth_callback():
             return jsonify({"error": "Google OAuth not configured"}), HTTPStatus.INTERNAL_SERVER_ERROR
 
         # Restore PKCE code_verifier from the initial auth request
-        flow.code_verifier = session.pop("code_verifier", None)
+        code_verifier = session.pop("code_verifier", None)
+        if code_verifier is None:
+            # code_verifier missing despite a valid state — PKCE handshake is broken.
+            # Restart the flow; the stale authorization code can't be exchanged anyway.
+            app.logger.warning("OAuth callback: code_verifier missing despite valid state, restarting OAuth flow")
+            return redirect(url_for("auth_google"))
+        flow.code_verifier = code_verifier
         app.logger.info(
-            f"OAuth callback: Retrieved code_verifier from session: {flow.code_verifier is not None} (length: {len(flow.code_verifier) if flow.code_verifier else 0})"
+            f"OAuth callback: Retrieved code_verifier from session (length: {len(code_verifier)})"
         )
         app.logger.info(f"OAuth callback: Session keys present: {list(session.keys())}")
         flow.fetch_token(authorization_response=request.url)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -198,6 +198,36 @@ class TestClearInitialSync:
         assert data["needs_initial_sync"] is False
 
 
+class TestAuthCallback:
+    """Tests for the OAuth callback endpoint."""
+
+    def test_callback_redirects_when_session_cleared(self, client):
+        """Callback with no session state (browser restart) should redirect to /auth/google."""
+        # No session set — simulates browser restart clearing the cookie
+        response = client.get("/auth/callback?state=some_state&code=some_code")
+        assert response.status_code == 302
+        assert "/auth/google" in response.headers["Location"]
+
+    def test_callback_redirects_when_code_verifier_missing(self, app, client):
+        """Callback with state but no code_verifier should redirect to /auth/google."""
+        with client.session_transaction() as sess:
+            sess["oauth_state"] = "valid_state"
+            # Deliberately omit code_verifier to simulate partial session loss
+
+        response = client.get("/auth/callback?state=valid_state&code=some_code")
+        assert response.status_code == 302
+        assert "/auth/google" in response.headers["Location"]
+
+    def test_callback_returns_400_on_state_mismatch(self, client):
+        """Callback with mismatched state should return 400 (CSRF protection)."""
+        with client.session_transaction() as sess:
+            sess["oauth_state"] = "expected_state"
+            sess["code_verifier"] = "some_verifier"
+
+        response = client.get("/auth/callback?state=tampered_state&code=some_code")
+        assert response.status_code == 400
+
+
 class TestStaticPages:
     """Tests for static pages."""
 


### PR DESCRIPTION
## Summary

- Adds an explicit `stored_state is None` check: when the Flask session is gone (browser restart cleared the cookie), redirect to `/auth/google` instead of crashing
- Adds a `code_verifier is None` check: if the PKCE verifier is missing despite a valid state, restart the flow rather than letting `fetch_token` blow up with `invalid_grant`
- Cleans up the log message for the happy path (no more redundant boolean + length)

**Root cause:** Flask uses browser-session cookies (no explicit expiry). When the browser restarts with tab restore enabled, it replays the OAuth callback URL, but the session holding the `code_verifier` is gone. Google rejects the token exchange with `(invalid_grant) Missing code verifier` because the original authorization URL included a PKCE `code_challenge` that now has no matching verifier.

## Test plan

- [ ] Restart browser mid-OAuth (on the Google account selection page) — should redirect cleanly to login instead of error page
- [ ] Normal login flow still works end-to-end
- [ ] Check logs for `"restarting OAuth flow"` entries confirm the redirect path fires