### PR TITLE
fix: rebuild :latest on every merge to main (kill the OAuth recurrence forever)

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -2,6 +2,8 @@ name: Build and Push Container
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -63,10 +63,18 @@ The application follows [Semantic Versioning](https://semver.org/) (semver):
 - **Minor** (x.Y.0): New features or significant enhancements (e.g., new UI capabilities)
 - **Patch** (x.y.Z): Bug fixes, performance improvements, or minor tweaks
 
-Version tags trigger container builds via GitHub Actions. After merging a PR:
-1. Determine version bump type based on changes
-2. Create and push git tag (e.g., `v1.14.0`)
-3. Verify container build succeeds
+Container builds via GitHub Actions MUST trigger on BOTH:
+- `push: branches: [main]` — every merge to `main` rebuilds `:latest` automatically, so production never lags behind `main`.
+- `push: tags: [v*]` — version tags additionally publish an immutable `:vX.Y.Z` tag.
+
+Container image tags MUST be unique to this repository. No other repository — including archived siblings or forks — may publish to the same `quay.io/crunchtools/<image>` tag. A zombie repo sharing a tag will silently overwrite production. (See 2026-05-19 incident: `acquacotta-old`'s weekly cron clobbered the OAuth fix six times in a row.)
+
+Deployed systemd units on lotor MUST include `--label io.containers.autoupdate=registry` and `--label PODMAN_SYSTEMD_UNIT=<unit>.service` so the nightly `podman-auto-update.timer` pulls new `:latest` images automatically.
+
+After merging a PR:
+1. Confirm the merge-to-`main` build pushed `:latest` to quay.
+2. Determine version bump type based on changes; tag (e.g., `v1.14.0`) and push to also publish a `:vX.Y.Z` tag.
+3. Lotor auto-update reconciles overnight; force-pull with `podman auto-update` on lotor if urgent.
 
 ## Governance
 
@@ -78,4 +86,4 @@ This constitution supersedes informal practices and ad-hoc decisions. Amendments
 
 All development decisions MUST align with these principles. When principles conflict, prioritize in order: Privacy, User Data Ownership, Simplicity, Timer Agnosticism, Offline-First, Container-Ready.
 
-**Version**: 1.2.0 | **Ratified**: 2025-12-27 | **Last Amended**: 2025-12-27
+**Version**: 1.3.0 | **Ratified**: 2025-12-27 | **Last Amended**: 2026-05-19


### PR DESCRIPTION
## Why

The OAuth `Missing code verifier` error on acquacotta.crunchtools.com has recurred **six times** since early 2026. Each recurrence triggered a different code-level "fix" (tmpfs → persistent volume → signed cookies → signed `state`). The signed-`state` fix in #72 (commit `ac182fb`, 2026-05-02) was actually correct.

The fixes kept getting overwritten by the archived sibling repo `crunchtools/acquacotta-old`, which had a weekly GHA cron (`30 4 * * 1`, Mondays 04:30 UTC) rebuilding pre-fix code and pushing to the same `quay.io/crunchtools/acquacotta:latest` tag. Every fix shipped from this repo got clobbered the following Monday morning.

`acquacotta-old` was archived on 2026-05-19 (disables all workflows). Production was force-rebuilt and pulled on lotor the same day; OAuth now works.

This PR closes the remaining gap so the OAuth fix — and every future fix — actually ships on merge.

## Changes

- **`.github/workflows/container-build.yml`** — add `push: branches: [main]` trigger. Every merge to `main` now rebuilds and pushes `:latest`. Existing `v*` tag and `workflow_dispatch` triggers retained.
- **`.specify/memory/constitution.md`** (v1.2.0 → v1.3.0) — Release & Versioning section now mandates:
  - Builds trigger on BOTH `push:main` and `push:tags:v*`.
  - Image tags are unique to one repository (no zombie siblings).
  - Deployed systemd units carry `io.containers.autoupdate=registry` + `PODMAN_SYSTEMD_UNIT` labels so lotor's nightly `podman-auto-update.timer` pulls automatically.

## Verification

After merge:
- [ ] GHA "Build and Push Container" runs on the merge commit (proves the new trigger fires).
- [ ] New image lands at `quay.io/crunchtools/acquacotta:latest` with the merge SHA in labels.
- [ ] `ssh -p 22422 root@lotor.dc3.crunchtools.com 'podman auto-update --dry-run'` lists `acquacotta.crunchtools.com.service`.
- [ ] OAuth login at https://acquacotta.crunchtools.com succeeds.

No app.py changes; OAuth code already correct.