### PR TITLE
acquacotta: constitution compliance (header + Web Application profile sections)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,5 +1,15 @@
 # Acquacotta Constitution
 
+> **Version:** 1.3.0
+> **Ratified:** 2025-12-27
+> **Status:** Active
+> **Inherits:** [crunchtools/constitution](https://github.com/crunchtools/constitution) v1.6.0
+> **Profile:** Web Application
+
+## License
+
+AGPL-3.0-or-later. See the universal [crunchtools/constitution](https://github.com/crunchtools/constitution).
+
 ## Core Principles
 
 ### I. Privacy by Design
@@ -75,6 +85,27 @@ After merging a PR:
 1. Confirm the merge-to-`main` build pushed `:latest` to quay.
 2. Determine version bump type based on changes; tag (e.g., `v1.14.0`) and push to also publish a `:vX.Y.Z` tag.
 3. Lotor auto-update reconciles overnight; force-pull with `podman auto-update` on lotor if urgent.
+
+## Deployment & Operations
+
+### Host Layout
+Deployed on lotor at `/srv/acquacotta.crunchtools.com/` following the standard
+`code/` / `config/` / `data/` convention; the container bind-mounts these
+directories and publishes `127.0.0.1:8080:80` behind the crunchtools reverse proxy.
+
+### Monitoring
+Monitored by Zabbix: a web scenario against `https://acquacotta.crunchtools.com`,
+a container-port check on `:8080`, and a Gunicorn process check.
+
+### Testing
+| Test | What it verifies |
+|------|------------------|
+| **Build test** | CI builds the image from the Containerfile on every push and PR |
+| **Smoke test** | Container starts and the Flask app answers a health check on `:8080` |
+
+### Cascade Rebuild
+Rebuilds weekly and on `repository_dispatch` when the parent image updates
+(parent-image-updated cascade), picking up base-image security fixes.
 
 ## Governance
 


### PR DESCRIPTION
acquacotta's constitution was an older spec-kit doc with no crunchtools header, so it had no Profile (only universal checks ran). Adds the `Inherits`/`Profile: Web Application` header, AGPL-3.0 reference, and the required Web Application sections (Host Layout, Monitoring, Testing, Cascade Rebuild).

Validated locally against `crunchtools/constitution` → **PASS — All checks passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)