### PR TITLE
fix: container-base.yml listens for parent-image-updated

### DIFF
--- a/.github/workflows/container-base.yml
+++ b/.github/workflows/container-base.yml
@@ -10,6 +10,8 @@ on:
       - 'requirements-dev.txt'
       - 'static/acquacotta-http.conf'
       - 'static/entrypoint.sh'
+  repository_dispatch:
+    types: [parent-image-updated]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Pairs with the rebase: acquacotta-base is FROM ubi10-core now, so when ubi10-core dispatches acquacotta, container-base.yml needs to listen and rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)