### PR TITLE
fix: replace entrypoint.sh with systemd units for httpd and gunicorn

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,5 +13,3 @@ COPY app.py .
 COPY sheets_storage.py .
 COPY templates/ templates/
 COPY static/ static/
-
-CMD ["/entrypoint.sh"]

--- a/Containerfile.base
+++ b/Containerfile.base
@@ -7,7 +7,7 @@
 FROM quay.io/crunchtools/ubi10-core:latest
 
 # Install system packages (slow)
-RUN dnf install -y python3.12 python3.12-pip httpd procps-ng && dnf clean all
+RUN dnf install -y python3.12 python3.12-pip httpd procps-ng systemd && dnf clean all
 
 WORKDIR /app
 
@@ -19,10 +19,14 @@ RUN pip3.12 install --no-cache-dir -r requirements.txt
 COPY static/acquacotta-http.conf /etc/httpd/conf.d/acquacotta.conf
 RUN rm -f /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/welcome.conf
 
-# Entrypoint script
-COPY static/entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+# Gunicorn systemd unit
+COPY static/gunicorn.service /etc/systemd/system/gunicorn.service
+
+# Enable services — systemd starts them on boot
+RUN systemctl enable httpd gunicorn
 
 ENV FLASK_HOST=127.0.0.1
 
 EXPOSE 80
+
+ENTRYPOINT ["/sbin/init"]

--- a/static/gunicorn.service
+++ b/static/gunicorn.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Gunicorn WSGI server for Acquacotta
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/app
+PassEnvironment=FLASK_SECRET_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET XDG_DATA_HOME FLASK_HOST
+ExecStart=/usr/local/bin/gunicorn --bind 127.0.0.1:5000 --workers 2 --access-logfile - --error-logfile - app:app
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Added `gunicorn.service` systemd unit for the Flask WSGI server
- Added `systemd` package to `Containerfile.base` 
- Enabled both `httpd` and `gunicorn` via `systemctl enable`
- Removed `CMD ["/entrypoint.sh"]` — systemd manages process lifecycle
- Added `PassEnvironment` for Flask env vars

## Root Cause
The `ubi10-core` base image has `/sbin/init` as `ENTRYPOINT`. The old `CMD ["/entrypoint.sh"]` was passed as an argument to systemd, which ignored it. Neither httpd nor gunicorn started.

## Test plan
- [x] Local build: base + app images build successfully
- [x] Local test: HTTP 200 on port 80
- [x] Both httpd and gunicorn show `active (running)` via systemctl
- [ ] Deploy to lotor and verify acquacotta.crunchtools.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)