### PR TITLE
Plugin architecture with storage abstraction

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ WORKDIR /app
 
 # Copy only application code (fast)
 COPY app.py .
+COPY plugin_registry.py .
+COPY storage_api.py .
 COPY sheets_storage.py .
 COPY templates/ templates/
 COPY static/ static/

--- a/app.py
+++ b/app.py
@@ -30,7 +30,13 @@ from googleapiclient.errors import HttpError
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+import plugin_registry
 import sheets_storage
+import storage_api
+
+# Register built-in plugins
+plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLUGIN_METADATA)
+plugin_registry.activate_storage("sheets")
 
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
@@ -269,6 +275,16 @@ def get_drive_service():
     if not credentials:
         return None
     return build("drive", "v3", credentials=credentials)
+
+
+def _storage_context():
+    """Build storage context for the active backend, or None if no backend is active."""
+    backend = plugin_registry.get_active_storage()
+    if backend is None:
+        return None
+    credentials = get_credentials()
+    request_creds = get_credentials_from_request()
+    return backend.build_context(credentials, request_creds)
 
 
 def is_logged_in():
@@ -672,9 +688,51 @@ def update_spreadsheet():
 
 
 # =============================================================================
-# Google Sheets Proxy Endpoints
-# The server proxies all data operations to Google Sheets.
-# No user data is stored on the server.
+# Plugin API
+# =============================================================================
+
+
+@app.route("/api/plugins")
+def api_list_plugins():
+    """List all registered plugins with their status."""
+    return jsonify({
+        "plugins": plugin_registry.list_plugins(),
+        "types": plugin_registry.list_plugin_types(),
+        "active_storage": plugin_registry.get_active_storage_id(),
+    })
+
+
+@app.route("/api/plugins/toggle", methods=["POST"])
+def api_toggle_plugin():
+    """Enable or disable a plugin."""
+    data = request.get_json(silent=True)
+    if not data or "plugin_id" not in data or "plugin_type" not in data:
+        return jsonify({"error": "plugin_id and plugin_type required"}), HTTPStatus.BAD_REQUEST
+
+    plugin_type = data["plugin_type"]
+    plugin_id = data["plugin_id"]
+    enable = data.get("enable", True)
+
+    if plugin_type == "storage":
+        if enable:
+            try:
+                plugin_registry.activate_storage(plugin_id)
+            except ValueError as e:
+                return jsonify({"error": str(e)}), HTTPStatus.BAD_REQUEST
+        else:
+            plugin_registry.deactivate_storage()
+    else:
+        return jsonify({"error": f"Toggle not yet supported for type: {plugin_type}"}), HTTPStatus.BAD_REQUEST
+
+    return jsonify({
+        "status": "ok",
+        "active_storage": plugin_registry.get_active_storage_id(),
+    })
+
+
+# =============================================================================
+# Storage Proxy Endpoints
+# Routes proxy data operations through the active storage plugin.
 # =============================================================================
 
 
@@ -685,11 +743,10 @@ def proxy_get_pomodoros():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
+        ctx = _storage_context()
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
-        pomodoros = sheets_storage.get_pomodoros(service, spreadsheet_id, start_date, end_date)
+        pomodoros = storage_api.get_pomodoros(ctx, start_date, end_date)
         return jsonify(pomodoros)
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -697,26 +754,13 @@ def proxy_get_pomodoros():
 
 @app.route("/api/sheets/pomodoros/count")
 def proxy_get_pomodoro_count():
-    """Get count of pomodoros in Google Sheets - efficient, only fetches IDs."""
+    """Get count of pomodoros - efficient, only fetches IDs."""
     if not is_logged_in():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        # Only fetch the ID column to count rows efficiently
-        sheets_response = (
-            service.spreadsheets()
-            .values()
-            .get(
-                spreadsheetId=spreadsheet_id,
-                range="Pomodoros!A:A",
-            )
-            .execute()
-        )
-        rows = sheets_response.get("values", [])
-        # Subtract 1 for header row, ensure non-negative
-        count = max(0, len(rows) - 1)
+        ctx = _storage_context()
+        count = storage_api.count_pomodoros(ctx)
         return jsonify({"count": count})
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -737,14 +781,13 @@ def proxy_create_pomodoro():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        if not service:
-            return jsonify({"error": "Failed to create Sheets service - invalid credentials"}), HTTPStatus.UNAUTHORIZED
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        if not spreadsheet_id:
-            return jsonify({"error": "No spreadsheet ID provided"}), HTTPStatus.BAD_REQUEST
+        ctx = _storage_context()
+        if not ctx.get("service"):
+            return jsonify({"error": "Failed to create storage service - invalid credentials"}), HTTPStatus.UNAUTHORIZED
+        if not ctx.get("location"):
+            return jsonify({"error": "No storage location provided"}), HTTPStatus.BAD_REQUEST
         pomodoro = get_request_data()
-        sheets_storage.save_pomodoro(service, spreadsheet_id, pomodoro)
+        storage_api.save_pomodoro(ctx, pomodoro)
         return jsonify({"status": "ok", "id": pomodoro.get("id")})
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -762,15 +805,14 @@ def proxy_create_pomodoros_batch():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        if not service:
-            return jsonify({"error": "Failed to create Sheets service"}), HTTPStatus.UNAUTHORIZED
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        if not spreadsheet_id:
-            return jsonify({"error": "No spreadsheet ID provided"}), HTTPStatus.BAD_REQUEST
+        ctx = _storage_context()
+        if not ctx.get("service"):
+            return jsonify({"error": "Failed to create storage service"}), HTTPStatus.UNAUTHORIZED
+        if not ctx.get("location"):
+            return jsonify({"error": "No storage location provided"}), HTTPStatus.BAD_REQUEST
         batch_request = get_request_data()
         pomodoros = batch_request.get("pomodoros", [])
-        count = sheets_storage.save_pomodoros_batch(service, spreadsheet_id, pomodoros)
+        count = storage_api.save_pomodoros_batch(ctx, pomodoros)
         return jsonify({"status": "ok", "count": count})
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -788,10 +830,9 @@ def proxy_update_pomodoro(pomodoro_id):
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
+        ctx = _storage_context()
         update_fields = get_request_data()
-        success = sheets_storage.update_pomodoro(service, spreadsheet_id, pomodoro_id, update_fields)
+        success = storage_api.update_pomodoro(ctx, pomodoro_id, update_fields)
         if success:
             return jsonify({"status": "ok"})
         return jsonify({"error": "Pomodoro not found"}), HTTPStatus.NOT_FOUND
@@ -801,14 +842,13 @@ def proxy_update_pomodoro(pomodoro_id):
 
 @app.route("/api/sheets/pomodoros/<pomodoro_id>", methods=["DELETE"])
 def proxy_delete_pomodoro(pomodoro_id):
-    """Proxy delete to Google Sheets - stateless, credentials from request."""
+    """Proxy delete to storage backend - stateless, credentials from request."""
     if not is_logged_in():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        success = sheets_storage.delete_pomodoro(service, spreadsheet_id, pomodoro_id)
+        ctx = _storage_context()
+        success = storage_api.delete_pomodoro(ctx, pomodoro_id)
         if success:
             return jsonify({"status": "ok"})
         return jsonify({"error": "Pomodoro not found"}), HTTPStatus.NOT_FOUND
@@ -823,9 +863,8 @@ def proxy_get_settings():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        settings = sheets_storage.get_settings(service, spreadsheet_id, DEFAULT_SETTINGS)
+        ctx = _storage_context()
+        settings = storage_api.get_settings(ctx, DEFAULT_SETTINGS)
         return jsonify(settings)
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -833,17 +872,16 @@ def proxy_get_settings():
 
 @app.route("/api/sheets/settings", methods=["POST"])
 def proxy_save_settings():
-    """Proxy settings write to Google Sheets - stateless."""
+    """Proxy settings write to storage backend - stateless."""
     if not is_logged_in():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
+        ctx = _storage_context()
         settings_payload = get_request_data()
         # Check for replace_all flag (used by "Overwrite Google" button)
         replace_all = settings_payload.pop("_replace_all", False) if isinstance(settings_payload, dict) else False
-        sheets_storage.save_settings(service, spreadsheet_id, settings_payload, replace_all=replace_all)
+        storage_api.save_settings(ctx, settings_payload, replace_all=replace_all)
         return jsonify({"status": "ok"})
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -856,9 +894,8 @@ def proxy_deduplicate_pomodoros():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        dedup_result = sheets_storage.deduplicate_pomodoros(service, spreadsheet_id)
+        ctx = _storage_context()
+        dedup_result = storage_api.deduplicate_pomodoros(ctx)
         return jsonify(dedup_result)
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
@@ -871,9 +908,8 @@ def proxy_export_csv():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-        pomodoros = sheets_storage.get_pomodoros(service, spreadsheet_id)
+        ctx = _storage_context()
+        pomodoros = storage_api.get_pomodoros(ctx)
 
         lines = ["id,name,type,start_time,end_time,duration_minutes,notes"]
         for p in pomodoros:
@@ -900,48 +936,11 @@ def proxy_clear_sheets():
         return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
 
     try:
-        service = get_sheets_service()
-        spreadsheet_id = get_spreadsheet_id_from_request()
-
-        # Get the sheet ID for Pomodoros sheet
-        spreadsheet = service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
-        pomodoros_sheet_id = None
-        for sheet in spreadsheet["sheets"]:
-            if sheet["properties"]["title"] == "Pomodoros":
-                pomodoros_sheet_id = sheet["properties"]["sheetId"]
-                break
-
-        if pomodoros_sheet_id is None:
-            return jsonify({"error": "Pomodoros sheet not found"}), HTTPStatus.NOT_FOUND
-
-        # Get current row count
-        values = service.spreadsheets().values().get(spreadsheetId=spreadsheet_id, range="Pomodoros!A:A").execute()
-        row_count = len(values.get("values", []))
-
-        if row_count <= 1:
-            # Only header or empty, nothing to clear
-            return jsonify({"status": "ok", "cleared": 0})
-
-        # Delete all data rows (keep header at row 1)
-        service.spreadsheets().batchUpdate(
-            spreadsheetId=spreadsheet_id,
-            body={
-                "requests": [
-                    {
-                        "deleteDimension": {
-                            "range": {
-                                "sheetId": pomodoros_sheet_id,
-                                "dimension": "ROWS",
-                                "startIndex": 1,  # After header
-                                "endIndex": row_count,
-                            }
-                        }
-                    }
-                ]
-            },
-        ).execute()
-
-        return jsonify({"status": "ok", "cleared": row_count - 1})
+        ctx = _storage_context()
+        result = storage_api.clear_pomodoros(ctx)
+        if result.get("error"):
+            return jsonify({"error": result["error"]}), HTTPStatus.NOT_FOUND
+        return jsonify(result)
     except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -1,0 +1,133 @@
+"""Acquacotta Plugin Registry — type system, contracts, and discovery."""
+
+PLUGIN_TYPES = {
+    "storage": {
+        "description": "Data storage backends",
+        "contract": [
+            "get_pomodoros",
+            "save_pomodoro",
+            "save_pomodoros_batch",
+            "update_pomodoro",
+            "delete_pomodoro",
+            "get_settings",
+            "save_settings",
+            "deduplicate_pomodoros",
+            "count_pomodoros",
+            "clear_pomodoros",
+            "build_context",
+        ],
+        "singleton": True,
+    },
+    "extension": {
+        "description": "Dashboard extensions (tabs, data)",
+        "contract": [],
+        "singleton": False,
+    },
+    "integration": {
+        "description": "External system integrations",
+        "contract": [],
+        "singleton": False,
+    },
+    "import": {
+        "description": "One-time data migration tools",
+        "contract": [],
+        "singleton": False,
+    },
+}
+
+# Registry: plugin_type -> {plugin_id -> {"module": mod, "metadata": dict, "active": bool}}
+_plugins = {}
+
+# Active storage backend id
+_active_storage = None
+
+
+def register(plugin_type, plugin_id, module, metadata):
+    """Register a plugin. Validates it implements the required contract."""
+    if plugin_type not in PLUGIN_TYPES:
+        raise ValueError(f"Unknown plugin type: {plugin_type}")
+
+    contract = PLUGIN_TYPES[plugin_type]["contract"]
+    missing = [fn for fn in contract if not callable(getattr(module, fn, None))]
+    if missing:
+        raise ValueError(
+            f"Plugin '{plugin_id}' missing required functions: {', '.join(missing)}"
+        )
+
+    if plugin_type not in _plugins:
+        _plugins[plugin_type] = {}
+
+    _plugins[plugin_type][plugin_id] = {
+        "module": module,
+        "metadata": metadata,
+        "active": False,
+    }
+
+
+def activate_storage(plugin_id):
+    """Set the active storage backend."""
+    global _active_storage
+    if "storage" not in _plugins or plugin_id not in _plugins["storage"]:
+        raise ValueError(f"Storage plugin not registered: {plugin_id}")
+
+    for pid in _plugins["storage"]:
+        _plugins["storage"][pid]["active"] = pid == plugin_id
+
+    _active_storage = plugin_id
+
+
+def deactivate_storage():
+    """Disable cloud storage sync. App falls back to local IndexedDB only."""
+    global _active_storage
+    if "storage" in _plugins:
+        for pid in _plugins["storage"]:
+            _plugins["storage"][pid]["active"] = False
+    _active_storage = None
+
+
+def get_active_storage():
+    """Get the currently active storage backend module, or None if disabled."""
+    if _active_storage is None:
+        return None
+    return _plugins["storage"][_active_storage]["module"]
+
+
+def get_active_storage_id():
+    """Get the id of the currently active storage backend."""
+    return _active_storage
+
+
+def get_plugin(plugin_type, plugin_id):
+    """Get a specific plugin's module by type and id."""
+    if plugin_type in _plugins and plugin_id in _plugins[plugin_type]:
+        return _plugins[plugin_type][plugin_id]["module"]
+    return None
+
+
+def list_plugins(plugin_type=None):
+    """List all registered plugins, optionally filtered by type."""
+    result = []
+    types_to_list = [plugin_type] if plugin_type else PLUGIN_TYPES.keys()
+
+    for ptype in types_to_list:
+        if ptype not in _plugins:
+            continue
+        for pid, info in _plugins[ptype].items():
+            entry = dict(info["metadata"])
+            entry["active"] = info["active"]
+            entry["plugin_type"] = ptype
+            result.append(entry)
+
+    return result
+
+
+def list_plugin_types():
+    """List all available plugin types with descriptions."""
+    return {
+        ptype: {
+            "description": info["description"],
+            "singleton": info["singleton"],
+            "registered_count": len(_plugins.get(ptype, {})),
+        }
+        for ptype, info in PLUGIN_TYPES.items()
+    }

--- a/sheets_storage.py
+++ b/sheets_storage.py
@@ -2,9 +2,29 @@
 
 import json
 
+PLUGIN_METADATA = {
+    "id": "sheets",
+    "name": "Google Sheets",
+    "description": "Store data in your Google Sheets spreadsheet",
+    "version": "1.0.0",
+    "type": "storage",
+    "author": "crunchtools",
+}
+
 # Column counts for Sheets data validation
 POMODORO_MIN_COLUMNS = 6  # id, name, type, start_time, end_time, duration_minutes
 POMODORO_TOTAL_COLUMNS = 7  # includes optional notes column
+
+
+def build_context(credentials, request_creds):
+    """Build Sheets-specific storage context from credentials."""
+    from googleapiclient.discovery import build
+
+    service = build("sheets", "v4", credentials=credentials)
+    return {
+        "service": service,
+        "location": request_creds.get("spreadsheet_id"),
+    }
 SETTINGS_MIN_COLUMNS = 2  # key, value
 
 
@@ -442,3 +462,63 @@ def save_settings(sheets_service, spreadsheet_id, settings_data, replace_all=Fal
             insertDataOption="INSERT_ROWS",
             body={"values": appends},
         ).execute()
+
+
+def count_pomodoros(sheets_service, spreadsheet_id):
+    """Count pomodoros efficiently by fetching only the ID column."""
+    sheets_response = (
+        sheets_service.spreadsheets()
+        .values()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            range="Pomodoros!A:A",
+        )
+        .execute()
+    )
+    rows = sheets_response.get("values", [])
+    return max(0, len(rows) - 1)
+
+
+def clear_pomodoros(sheets_service, spreadsheet_id):
+    """Clear all pomodoro data rows (keeps headers)."""
+    spreadsheet = sheets_service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
+
+    sheet_id = None
+    for sheet in spreadsheet["sheets"]:
+        if sheet["properties"]["title"] == "Pomodoros":
+            sheet_id = sheet["properties"]["sheetId"]
+            break
+
+    if sheet_id is None:
+        return {"status": "error", "error": "Pomodoros sheet not found", "cleared": 0}
+
+    values = (
+        sheets_service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range="Pomodoros!A:A")
+        .execute()
+    )
+    row_count = len(values.get("values", []))
+
+    if row_count <= 1:
+        return {"status": "ok", "cleared": 0}
+
+    sheets_service.spreadsheets().batchUpdate(
+        spreadsheetId=spreadsheet_id,
+        body={
+            "requests": [
+                {
+                    "deleteDimension": {
+                        "range": {
+                            "sheetId": sheet_id,
+                            "dimension": "ROWS",
+                            "startIndex": 1,
+                            "endIndex": row_count,
+                        }
+                    }
+                }
+            ]
+        },
+    ).execute()
+
+    return {"status": "ok", "cleared": row_count - 1}

--- a/storage_api.py
+++ b/storage_api.py
@@ -1,0 +1,58 @@
+"""Acquacotta Storage API — dispatch layer for storage backend plugins."""
+
+import plugin_registry
+
+
+def is_active():
+    """Check if a storage backend is active."""
+    return plugin_registry.get_active_storage() is not None
+
+
+def get_pomodoros(ctx, start_date=None, end_date=None):
+    backend = plugin_registry.get_active_storage()
+    return backend.get_pomodoros(ctx["service"], ctx["location"], start_date, end_date)
+
+
+def save_pomodoro(ctx, pomodoro):
+    backend = plugin_registry.get_active_storage()
+    return backend.save_pomodoro(ctx["service"], ctx["location"], pomodoro)
+
+
+def save_pomodoros_batch(ctx, pomodoros):
+    backend = plugin_registry.get_active_storage()
+    return backend.save_pomodoros_batch(ctx["service"], ctx["location"], pomodoros)
+
+
+def update_pomodoro(ctx, pomodoro_id, update_fields):
+    backend = plugin_registry.get_active_storage()
+    return backend.update_pomodoro(ctx["service"], ctx["location"], pomodoro_id, update_fields)
+
+
+def delete_pomodoro(ctx, pomodoro_id):
+    backend = plugin_registry.get_active_storage()
+    return backend.delete_pomodoro(ctx["service"], ctx["location"], pomodoro_id)
+
+
+def get_settings(ctx, defaults):
+    backend = plugin_registry.get_active_storage()
+    return backend.get_settings(ctx["service"], ctx["location"], defaults)
+
+
+def save_settings(ctx, settings_data, replace_all=False):
+    backend = plugin_registry.get_active_storage()
+    return backend.save_settings(ctx["service"], ctx["location"], settings_data, replace_all=replace_all)
+
+
+def deduplicate_pomodoros(ctx):
+    backend = plugin_registry.get_active_storage()
+    return backend.deduplicate_pomodoros(ctx["service"], ctx["location"])
+
+
+def count_pomodoros(ctx):
+    backend = plugin_registry.get_active_storage()
+    return backend.count_pomodoros(ctx["service"], ctx["location"])
+
+
+def clear_pomodoros(ctx):
+    backend = plugin_registry.get_active_storage()
+    return backend.clear_pomodoros(ctx["service"], ctx["location"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -922,6 +922,12 @@
                 </div>
                 <button class="secondary" onclick="sortTypesAlphabetically()" style="width: 100%;">Sort A-Z</button>
             </div>
+            <div class="card">
+                <h3>Plugins</h3>
+                <p style="color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 1rem;">Extend Acquacotta with additional functionality</p>
+                <div id="plugins-list"></div>
+                <div id="plugins-loading" style="color: var(--text-secondary); font-size: 0.875rem;">Loading plugins...</div>
+            </div>
             <p style="color: var(--text-secondary); font-size: 0.75rem; text-align: center; margin-top: 1rem;">Settings are saved automatically</p>
         </div>
 
@@ -3530,6 +3536,94 @@
             // Update break info display
             updateBreakInfo();
             updateBreakButtonStyles();
+
+            // Load plugin list
+            loadPlugins();
+        }
+
+        async function loadPlugins() {
+            const container = document.getElementById('plugins-list');
+            const loading = document.getElementById('plugins-loading');
+            try {
+                const resp = await fetch('/api/plugins');
+                if (!resp.ok) throw new Error('Failed to load plugins');
+                const data = await resp.json();
+                loading.style.display = 'none';
+
+                if (!data.plugins || data.plugins.length === 0) {
+                    container.innerHTML = '<p style="color: var(--text-secondary); font-size: 0.875rem;">No plugins installed</p>';
+                    return;
+                }
+
+                container.innerHTML = data.plugins.map(plugin => {
+                    const isActive = plugin.active;
+                    const typeBadge = `<span style="display: inline-block; padding: 0.125rem 0.5rem; border-radius: 4px; font-size: 0.75rem; background: var(--bg-tertiary); color: var(--text-secondary);">${plugin.plugin_type}</span>`;
+                    const toggleId = `plugin-toggle-${plugin.id}`;
+                    const toggleChecked = isActive ? 'checked' : '';
+                    return `<div class="type-item" style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.5rem;">
+                        <div style="flex: 1;">
+                            <div style="font-weight: 500;">${plugin.name}</div>
+                            <div style="font-size: 0.8rem; color: var(--text-secondary); margin-top: 0.25rem;">${plugin.description}</div>
+                            <div style="display: flex; gap: 0.5rem; align-items: center; margin-top: 0.375rem;">
+                                ${typeBadge}
+                                <span style="font-size: 0.75rem; color: var(--text-secondary);">v${plugin.version}</span>
+                            </div>
+                        </div>
+                        <label style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; margin-left: 1rem;">
+                            <span style="font-size: 0.75rem; color: ${isActive ? 'var(--success)' : 'var(--text-secondary)'};">${isActive ? 'On' : 'Off'}</span>
+                            <input type="checkbox" id="${toggleId}" ${toggleChecked}
+                                data-plugin-id="${plugin.id}" data-plugin-type="${plugin.plugin_type}"
+                                onchange="togglePlugin(this)" style="width: auto; cursor: pointer;">
+                        </label>
+                    </div>`;
+                }).join('');
+
+                updateSyncCardVisibility(data.active_storage);
+            } catch (e) {
+                loading.textContent = 'Could not load plugins';
+            }
+        }
+
+        async function togglePlugin(checkbox) {
+            const pluginId = checkbox.dataset.pluginId;
+            const pluginType = checkbox.dataset.pluginType;
+            const enable = checkbox.checked;
+
+            try {
+                const resp = await fetch('/api/plugins/toggle', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ plugin_id: pluginId, plugin_type: pluginType, enable }),
+                });
+                if (!resp.ok) {
+                    checkbox.checked = !enable;
+                    return;
+                }
+                const data = await resp.json();
+                updateSyncCardVisibility(data.active_storage);
+                loadPlugins();
+            } catch (e) {
+                checkbox.checked = !enable;
+            }
+        }
+
+        function updateSyncCardVisibility(activeStorage) {
+            const syncCard = document.getElementById('google-account-card');
+            if (syncCard) {
+                syncCard.style.display = activeStorage ? '' : 'none';
+            }
+
+            const indicator = document.getElementById('storage-indicator');
+            const indicatorDot = document.getElementById('storage-indicator-dot');
+            const modeText = document.getElementById('storage-mode-text');
+            if (!activeStorage && indicator) {
+                indicator.style.display = 'block';
+                indicatorDot.style.background = '#f59e0b';
+                modeText.textContent = 'Local Storage';
+                indicator.title = 'No storage plugin active — data is stored locally only';
+            } else if (activeStorage && indicator) {
+                updateStorageIndicator();
+            }
         }
 
         // Timer preset sliders

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ All data storage and CRUD operations happen in the browser's IndexedDB.
 import json
 from unittest.mock import patch
 
-import sheets_storage
+import storage_api
 
 
 class TestIndexRoute:
@@ -95,88 +95,100 @@ class TestSheetsProxyEndpoints:
         response = client.get("/api/sheets/export")
         assert response.status_code == 401
 
-    def test_get_pomodoros_with_auth(self, authenticated_session, mock_sheets_service):
-        """GET /api/sheets/pomodoros should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(
-                sheets_storage,
-                "get_pomodoros",
-                return_value=[
-                    {
-                        "id": "test-1",
-                        "name": "Test",
-                        "type": "Content",
-                        "start_time": "2024-01-15T10:00:00Z",
-                        "end_time": "2024-01-15T10:25:00Z",
-                        "duration_minutes": 25,
-                        "notes": None,
-                    }
-                ],
-            ) as mock_get:
-                response = authenticated_session.get("/api/sheets/pomodoros")
-                assert response.status_code == 200
-                data = json.loads(response.data)
-                assert len(data) == 1
-                assert data[0]["name"] == "Test"
-                mock_get.assert_called_once()
+    def test_get_pomodoros_with_auth(self, authenticated_session):
+        """GET /api/sheets/pomodoros should proxy to storage backend when authenticated."""
+        with patch.object(
+            storage_api,
+            "get_pomodoros",
+            return_value=[
+                {
+                    "id": "test-1",
+                    "name": "Test",
+                    "type": "Content",
+                    "start_time": "2024-01-15T10:00:00Z",
+                    "end_time": "2024-01-15T10:25:00Z",
+                    "duration_minutes": 25,
+                    "notes": None,
+                }
+            ],
+        ) as mock_get:
+            response = authenticated_session.get("/api/sheets/pomodoros")
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert len(data) == 1
+            assert data[0]["name"] == "Test"
+            mock_get.assert_called_once()
 
-    def test_create_pomodoro_with_auth(self, authenticated_session, mock_sheets_service, sample_pomodoro):
-        """POST /api/sheets/pomodoros should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(sheets_storage, "save_pomodoro") as mock_save:
-                response = authenticated_session.post(
-                    "/api/sheets/pomodoros",
-                    json=sample_pomodoro,
-                    content_type="application/json",
-                )
-                assert response.status_code == 200
-                mock_save.assert_called_once()
+    def test_create_pomodoro_with_auth(self, authenticated_session, sample_pomodoro):
+        """POST /api/sheets/pomodoros should proxy to storage backend when authenticated."""
+        with patch.object(storage_api, "save_pomodoro") as mock_save:
+            response = authenticated_session.post(
+                "/api/sheets/pomodoros",
+                json=sample_pomodoro,
+                content_type="application/json",
+            )
+            assert response.status_code == 200
+            mock_save.assert_called_once()
 
-    def test_update_pomodoro_with_auth(self, authenticated_session, mock_sheets_service, sample_pomodoro):
-        """PUT /api/sheets/pomodoros/<id> should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(sheets_storage, "update_pomodoro", return_value=True) as mock_update:
-                response = authenticated_session.put(
-                    "/api/sheets/pomodoros/test-uuid-1234",
-                    json=sample_pomodoro,
-                    content_type="application/json",
-                )
-                assert response.status_code == 200
-                mock_update.assert_called_once()
+    def test_update_pomodoro_with_auth(self, authenticated_session, sample_pomodoro):
+        """PUT /api/sheets/pomodoros/<id> should proxy to storage backend when authenticated."""
+        with patch.object(storage_api, "update_pomodoro", return_value=True) as mock_update:
+            response = authenticated_session.put(
+                "/api/sheets/pomodoros/test-uuid-1234",
+                json=sample_pomodoro,
+                content_type="application/json",
+            )
+            assert response.status_code == 200
+            mock_update.assert_called_once()
 
-    def test_delete_pomodoro_with_auth(self, authenticated_session, mock_sheets_service):
-        """DELETE /api/sheets/pomodoros/<id> should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(sheets_storage, "delete_pomodoro", return_value=True) as mock_delete:
-                response = authenticated_session.delete("/api/sheets/pomodoros/test-uuid-1234")
-                assert response.status_code == 200
-                mock_delete.assert_called_once()
+    def test_delete_pomodoro_with_auth(self, authenticated_session):
+        """DELETE /api/sheets/pomodoros/<id> should proxy to storage backend when authenticated."""
+        with patch.object(storage_api, "delete_pomodoro", return_value=True) as mock_delete:
+            response = authenticated_session.delete("/api/sheets/pomodoros/test-uuid-1234")
+            assert response.status_code == 200
+            mock_delete.assert_called_once()
 
-    def test_get_settings_with_auth(self, authenticated_session, mock_sheets_service):
-        """GET /api/sheets/settings should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(
-                sheets_storage,
-                "get_settings",
-                return_value={"timer_preset_4": 25, "short_break_minutes": 5},
-            ) as mock_get:
-                response = authenticated_session.get("/api/sheets/settings")
-                assert response.status_code == 200
-                data = json.loads(response.data)
-                assert data["timer_preset_4"] == 25
-                mock_get.assert_called_once()
+    def test_get_settings_with_auth(self, authenticated_session):
+        """GET /api/sheets/settings should proxy to storage backend when authenticated."""
+        with patch.object(
+            storage_api,
+            "get_settings",
+            return_value={"timer_preset_4": 25, "short_break_minutes": 5},
+        ) as mock_get:
+            response = authenticated_session.get("/api/sheets/settings")
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data["timer_preset_4"] == 25
+            mock_get.assert_called_once()
 
-    def test_save_settings_with_auth(self, authenticated_session, mock_sheets_service, sample_settings):
-        """POST /api/sheets/settings should proxy to Sheets when authenticated."""
-        with patch("app.get_sheets_service", return_value=mock_sheets_service):
-            with patch.object(sheets_storage, "save_settings") as mock_save:
-                response = authenticated_session.post(
-                    "/api/sheets/settings",
-                    json=sample_settings,
-                    content_type="application/json",
-                )
-                assert response.status_code == 200
-                mock_save.assert_called_once()
+    def test_save_settings_with_auth(self, authenticated_session, sample_settings):
+        """POST /api/sheets/settings should proxy to storage backend when authenticated."""
+        with patch.object(storage_api, "save_settings") as mock_save:
+            response = authenticated_session.post(
+                "/api/sheets/settings",
+                json=sample_settings,
+                content_type="application/json",
+            )
+            assert response.status_code == 200
+            mock_save.assert_called_once()
+
+
+class TestPluginsAPI:
+    """Tests for the plugin registry API."""
+
+    def test_list_plugins(self, client):
+        """GET /api/plugins should return registered plugins."""
+        response = client.get("/api/plugins")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert "plugins" in data
+        assert "types" in data
+        assert "active_storage" in data
+        assert data["active_storage"] == "sheets"
+        sheets_plugin = next(p for p in data["plugins"] if p["id"] == "sheets")
+        assert sheets_plugin["name"] == "Google Sheets"
+        assert sheets_plugin["plugin_type"] == "storage"
+        assert sheets_plugin["active"] is True
 
 
 class TestClearInitialSync:


### PR DESCRIPTION
## Summary
- Introduces a plugin type system (storage, extension, integration, import) with contract validation and registry
- Wraps existing Google Sheets backend as the first storage plugin behind a dispatch layer
- All route handlers rewired through `storage_api.py` — no direct `sheets_storage` calls from `app.py`
- New `/api/plugins` and `/api/plugins/toggle` endpoints
- Settings UI shows installed plugins with enable/disable toggles
- Disabling the storage plugin reverts to local-only IndexedDB mode (header badge updates, sync card hides)
- Foundation for JSON on Drive (#83), Dropbox, and other storage backends as future plugins

## Test plan
- [x] All 41 existing tests pass with updated mocks
- [x] New `TestPluginsAPI` test verifies `/api/plugins` returns Sheets plugin
- [x] Container builds successfully
- [x] App loads, settings page shows Plugins section with toggle
- [x] Toggle off: header shows "Local Storage", Google Sheets Sync card hides
- [x] Toggle on: header restores sync status, sync card reappears
- [x] `/api/plugins` returns correct plugin list and active storage
- [x] `/api/plugins/toggle` enables/disables storage backend

Closes #82
Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)