### PR TITLE
feat: JSON storage core + Google Drive transport

### DIFF
--- a/.specify/specs/002-json-google-drive/plan.md
+++ b/.specify/specs/002-json-google-drive/plan.md
@@ -1,0 +1,210 @@
+# Implementation Plan: JSON Storage Core + Google Drive Transport
+
+**Branch**: `feature/83-json-google-drive` | **Date**: 2026-06-19 | **Spec**: `002-json-google-drive/spec.md`
+**Input**: Feature specification from `/specs/002-json-google-drive/spec.md`
+
+## Summary
+
+Replace the Google Sheets storage backend with a JSON-on-Google-Drive backend as the default for new users. Build a two-layer architecture: a shared `json_storage_core.py` (transport-agnostic CRUD/serialization) and a `transports/google_drive_transport.py` (4-function interface). Wire them together in `json_google_drive_storage.py` implementing the full 11-function storage contract. Refactor `app.py` to make `_storage_context()` and the OAuth callback plugin-aware.
+
+## Technical Context
+
+**Language/Version**: Python 3.x (Flask)
+**Primary Dependencies**: Flask, google-api-python-client, google-auth-oauthlib
+**Storage**: Google Drive API v3 (JSON files), IndexedDB (browser cache)
+**Testing**: Manual verification + existing test patterns
+**Target Platform**: Linux container (OCI), all modern browsers
+**Project Type**: Web application (monolith)
+**Performance Goals**: Sub-2-second full read for 2400+ pomodoros (vs. minutes with Sheets)
+**Constraints**: No new OAuth scopes, drive.file only, stateless server
+**Scale/Scope**: Single user per session, ~5 MB max data over a decade
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Privacy by Design | PASS | Same OAuth, same drive.file scope, no new data collection |
+| II. User Data Ownership | PASS | JSON on user's Drive is even more portable than Sheets |
+| III. Simplicity & Focus | PASS | Plugin architecture already approved (#80/#85), this adds a cleaner backend |
+| IV. Timer Agnosticism | N/A | Storage layer, not timer |
+| V. Offline-First | PASS | IndexedDB remains the primary read path; Drive is the sync target |
+| VI. Container-Ready | PASS | No new persistent volumes, same stateless design |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-json-google-drive/
+├── spec.md              # Feature specification
+└── plan.md              # This file
+```
+
+### Source Code (new and modified files)
+
+```text
+# New files
+json_storage_core.py                 # Shared JSON serialization, CRUD, filtering, dedup
+transports/                          # Transport implementations directory
+├── __init__.py
+└── google_drive_transport.py        # Google Drive API v3 transport (4 functions)
+json_google_drive_storage.py         # Storage plugin: core + transport, PLUGIN_METADATA
+
+# Modified files
+app.py                               # Plugin-aware _storage_context(), OAuth callback, default backend
+storage_api.py                       # Use plugin's build_context() instead of hardcoded Sheets logic
+```
+
+## Implementation Phases
+
+### Phase 1: JSON Storage Core (`json_storage_core.py`)
+
+The core module operates on plain Python dicts/lists. It doesn't know or care where JSON files live.
+
+**Functions to implement:**
+
+```python
+def parse_pomodoros(json_content: str | None) -> list[dict]
+def serialize_pomodoros(pomodoros: list[dict]) -> str
+def parse_settings(json_content: str | None) -> dict
+def serialize_settings(settings: dict) -> str
+def add_pomodoro(pomodoros: list[dict], pomodoro: dict) -> tuple[list[dict], bool]
+def add_pomodoros_batch(pomodoros: list[dict], new_pomodoros: list[dict]) -> tuple[list[dict], int]
+def update_pomodoro(pomodoros: list[dict], pomodoro_id: str, update_fields: dict) -> tuple[list[dict], bool]
+def delete_pomodoro(pomodoros: list[dict], pomodoro_id: str) -> tuple[list[dict], bool]
+def filter_by_date(pomodoros: list[dict], start_date: str | None, end_date: str | None) -> list[dict]
+def deduplicate(pomodoros: list[dict]) -> tuple[list[dict], int]
+def merge_settings(existing: dict, updates: dict, replace_all: bool) -> dict
+```
+
+Key design decisions:
+- All functions are pure — take data in, return data out
+- `add_pomodoro` returns `(updated_list, was_new)` for duplicate detection
+- Sort by `start_time` descending on read (matches Sheets behavior)
+- Invalid JSON returns empty list/dict, never crashes
+
+### Phase 2: Google Drive Transport (`transports/google_drive_transport.py`)
+
+Thin adapter around Google Drive API v3. ~80 lines.
+
+```python
+class GoogleDriveTransport:
+    def __init__(self, drive_service, folder_id):
+        ...
+    
+    def download_file(self, filename: str) -> str | None:
+        """Download a file from the Acquacotta folder. Returns content or None."""
+    
+    def upload_file(self, filename: str, content: str) -> None:
+        """Upload/overwrite a file in the Acquacotta folder."""
+    
+    def ensure_directory(self) -> str:
+        """Ensure Acquacotta/ folder exists, return folder_id."""
+    
+    def file_exists(self, filename: str) -> bool:
+        """Check if a file exists in the folder."""
+```
+
+Drive API operations:
+- `files().list()` with `q="name='X' and 'folder_id' in parents"` to find files
+- `files().get_media()` to download content
+- `files().create()` to create new files
+- `files().update()` with `media_body` to overwrite existing files
+- `files().create()` with `mimeType='application/vnd.google-apps.folder'` for directory
+
+### Phase 3: JSON Google Drive Storage Plugin (`json_google_drive_storage.py`)
+
+Wires core + transport. Implements all 11 storage contract functions. ~120 lines.
+
+```python
+PLUGIN_METADATA = {
+    "id": "json-google-drive",
+    "name": "JSON on Google Drive",
+    "description": "Store data as JSON files on your Google Drive",
+    "version": "1.0.0",
+    "type": "storage",
+    "author": "crunchtools",
+    "frontend_fields": ["folder_id"],
+    "auth_flow": "google_oauth",
+}
+
+def build_context(credentials, request_creds):
+    """Build Drive-specific storage context."""
+    service = build("drive", "v3", credentials=credentials)
+    return {"service": service, "location": request_creds.get("folder_id")}
+```
+
+Each function follows the pattern:
+1. Create transport from service + folder_id
+2. Download the relevant JSON file
+3. Parse with core
+4. Apply operation with core
+5. Serialize with core
+6. Upload back via transport
+
+### Phase 4: Plugin-Aware App Integration (`app.py` + `storage_api.py`)
+
+**4a. Refactor `_storage_context()`** — use the active plugin's `build_context()`:
+
+```python
+def _storage_context():
+    backend = plugin_registry.get_active_storage()
+    if backend is None:
+        return None
+    credentials = get_credentials()
+    if not credentials:
+        return None
+    request_creds = get_credentials_from_request()
+    if not request_creds:
+        return None
+    return backend.build_context(credentials, request_creds)
+```
+
+**4b. Refactor `is_logged_in()`** — check for plugin-appropriate location field:
+
+```python
+def is_logged_in():
+    creds = get_credentials_from_request()
+    if not creds or not creds.get("token"):
+        return False
+    backend = plugin_registry.get_active_storage()
+    if backend is None:
+        return True  # logged in but no backend (offline-only mode)
+    metadata = getattr(backend, 'PLUGIN_METADATA', {})
+    required_fields = metadata.get('frontend_fields', [])
+    return all(creds.get(f) for f in required_fields)
+```
+
+**4c. Refactor OAuth callback** — plugin-aware IndexedDB hydration:
+
+Instead of hardcoding `spreadsheet_id`, read from the active plugin's metadata:
+- `json-google-drive` → find/create `Acquacotta/` folder → write `folder_id` to IndexedDB
+- `sheets` → find/create spreadsheet → write `spreadsheet_id` to IndexedDB
+
+**4d. Change default backend** — register both plugins, activate `json-google-drive`:
+
+```python
+plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLUGIN_METADATA)
+plugin_registry.register("storage", "json-google-drive", json_google_drive_storage, json_google_drive_storage.PLUGIN_METADATA)
+plugin_registry.activate_storage("json-google-drive")  # New default
+```
+
+**4e. Remove `storage_api.py` hardcoded imports** — the dispatch layer already uses `plugin_registry.get_active_storage()`, but `StorageUnavailable` inherits from `HttpError` which is Sheets-specific. Make it a plain exception.
+
+### Phase 5: Frontend Credential Handling
+
+The frontend already sends credentials generically via `X-Credentials` header. The only change needed is that the OAuth callback JS writes `folder_id` instead of `spreadsheet_id` into IndexedDB when the JSON plugin is active. The `storage.js` module's `_getCredentials()` already reads from the `settings` store generically — it sends whatever is there.
+
+Verify that `storage.js` sends `folder_id` in the credentials payload when it's present in IndexedDB. If it only sends `spreadsheet_id`, add `folder_id` to the fields it includes.
+
+## Complexity Tracking
+
+No constitution violations. The plugin architecture was explicitly approved in constitution v2.0.0 (Principle III amendment, PR #85).
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Drive API rate limiting | Low | Single file read/write per operation, well within quotas |
+| Breaking existing Sheets users | Medium | Sheets plugin remains registered; existing users keep their `spreadsheet_id` in IndexedDB |
+| OAuth callback complexity | Medium | Careful refactor with fallback to current behavior if no `build_context` exists |

--- a/.specify/specs/002-json-google-drive/spec.md
+++ b/.specify/specs/002-json-google-drive/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: JSON Storage Core + Google Drive Transport
+
+**Feature Branch**: `feature/83-json-google-drive`  
+**Created**: 2026-06-19  
+**Status**: Draft  
+**Input**: GitHub Issue #83 — JSON storage core + Google Drive transport (json-google-drive plugin)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - New User Gets JSON Backend by Default (Priority: P1)
+
+A new user signs up via Google OAuth and their pomodoro data is stored as JSON files on their Google Drive instead of a Google Spreadsheet. The `Acquacotta/` folder and `pomodoros.json` / `settings.json` files are created automatically on first login.
+
+**Why this priority**: This is the core value proposition — faster, simpler storage that eliminates the Sheets API bottleneck (syncing 2402 pomodoros took minutes; a single JSON file write is sub-second).
+
+**Independent Test**: Log in with a fresh Google account. Verify `Acquacotta/` folder is created on Drive with `pomodoros.json` and `settings.json`. Save a pomodoro, reload, confirm it persists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new user with no Acquacotta data, **When** they complete OAuth login, **Then** an `Acquacotta/` folder is created on their Google Drive containing empty `pomodoros.json` and `settings.json` files, and `folder_id` is stored in IndexedDB.
+2. **Given** a logged-in new user, **When** they save their first pomodoro, **Then** it appears in `pomodoros.json` on Drive and is retrievable on page reload.
+
+---
+
+### User Story 2 - Existing User CRUD Operations (Priority: P1)
+
+A logged-in user can create, read, update, and delete pomodoros through the existing UI. All operations go through the JSON storage backend transparently — the user experience is identical to the Sheets backend but faster.
+
+**Why this priority**: Without full CRUD, the backend is unusable. This shares P1 with Story 1 because login without CRUD is meaningless.
+
+**Independent Test**: Log in, create 5 pomodoros, edit one, delete one, verify the remaining 4 are correct. Filter by date range. Run deduplication. Export CSV.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with existing pomodoros, **When** they view the history, **Then** all pomodoros are loaded from `pomodoros.json` sorted by start_time descending.
+2. **Given** a user editing a pomodoro, **When** they save changes, **Then** the update is reflected in `pomodoros.json` on Drive.
+3. **Given** a user deleting a pomodoro, **When** they confirm deletion, **Then** it is removed from `pomodoros.json` on Drive.
+4. **Given** a user with duplicate pomodoros, **When** they run deduplication, **Then** duplicates are removed and the count is reported.
+
+---
+
+### User Story 3 - Plugin-Aware Storage Context (Priority: P2)
+
+The `_storage_context()` function and OAuth callback dynamically adapt to whichever storage plugin is active. The Sheets plugin continues to work unchanged. The JSON plugin gets a Drive service and `folder_id` instead of a Sheets service and `spreadsheet_id`.
+
+**Why this priority**: Without this, the JSON plugin can't integrate into the existing app.py dispatch layer. But it's P2 because it's infrastructure, not user-visible.
+
+**Independent Test**: Activate the `json-google-drive` plugin, verify API calls use Drive. Switch back to `sheets`, verify API calls use Sheets.
+
+**Acceptance Scenarios**:
+
+1. **Given** `json-google-drive` is the active storage plugin, **When** any API endpoint calls `_storage_context()`, **Then** it returns a context with a Drive service and `folder_id` (not a Sheets service and `spreadsheet_id`).
+2. **Given** `sheets` is the active storage plugin, **When** any API endpoint calls `_storage_context()`, **Then** behavior is unchanged from current implementation.
+3. **Given** the OAuth callback completes, **When** `json-google-drive` is active, **Then** `folder_id` is written to IndexedDB settings store (not `spreadsheet_id`).
+
+---
+
+### User Story 4 - Settings Persistence (Priority: P2)
+
+User settings (timer presets, pomodoro types, sound preferences) are stored in `settings.json` on Drive and survive across sessions.
+
+**Why this priority**: Settings must work for the app to be usable, but a user can still track pomodoros with default settings.
+
+**Independent Test**: Change timer presets and pomodoro types, log out, log back in, verify settings are restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user saves custom settings, **When** they reload the page, **Then** settings are loaded from `settings.json` on Drive.
+2. **Given** a user uses "Overwrite Google" for settings, **When** the operation completes, **Then** `settings.json` on Drive matches the local settings exactly.
+
+---
+
+### Edge Cases
+
+- What happens when the `Acquacotta/` folder is deleted from Drive? → Re-create on next API call.
+- What happens when `pomodoros.json` is manually edited and contains invalid JSON? → Return empty list, don't crash.
+- What happens when the user has no network? → Offline-first IndexedDB handles it; sync fails gracefully.
+- What happens during concurrent writes from multiple tabs? → Last write wins (same as Sheets behavior).
+- What happens when `pomodoros.json` grows to 5 MB (a decade of data)? → Still sub-second read/write; Drive API handles it fine.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST implement `json_storage_core.py` with transport-agnostic serialization, CRUD, filtering, dedup, count, and clear operations.
+- **FR-002**: System MUST define a transport interface with `download_file`, `upload_file`, `ensure_directory`, and `file_exists` methods.
+- **FR-003**: System MUST implement `transports/google_drive_transport.py` implementing the transport interface using the Google Drive API v3.
+- **FR-004**: System MUST implement `json_google_drive_storage.py` wiring core + transport to fulfill the full storage plugin contract (11 functions).
+- **FR-005**: System MUST create `Acquacotta/` folder on Drive on first use via `ensure_directory`.
+- **FR-006**: System MUST read/write `pomodoros.json` and `settings.json` within the `Acquacotta/` folder.
+- **FR-007**: System MUST register as `json-google-drive` storage plugin with proper `PLUGIN_METADATA`.
+- **FR-008**: New users MUST default to `json-google-drive` backend.
+- **FR-009**: System MUST work with existing `drive.file` OAuth scope (no new permissions).
+- **FR-010**: System MUST implement plugin-aware `_storage_context()` using each plugin's `build_context()`.
+- **FR-011**: System MUST implement plugin-aware IndexedDB hydration in the OAuth callback, writing `folder_id` for JSON plugins and `spreadsheet_id` for Sheets.
+
+### Key Entities
+
+- **JsonStorageCore**: Transport-agnostic module handling serialization, CRUD, filtering, dedup on plain Python dicts/lists.
+- **GoogleDriveTransport**: Thin adapter implementing the 4-function transport interface against Google Drive API v3.
+- **JsonGoogleDriveStorage**: Storage plugin module wiring core + transport, implementing the 11-function storage contract.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Full read of all pomodoros completes in under 2 seconds (vs. minutes with Sheets for 2400+ records).
+- **SC-002**: All 11 storage contract functions pass integration tests against a real Google Drive folder.
+- **SC-003**: Existing Sheets backend continues to work unchanged when activated.
+- **SC-004**: Adding a future transport (e.g., pCloud) requires only ~50 lines of transport code + a thin plugin file.
+- **SC-005**: No new OAuth permissions required — `drive.file` scope covers both Sheets and Drive file operations.

--- a/Containerfile
+++ b/Containerfile
@@ -13,5 +13,8 @@ COPY app.py .
 COPY plugin_registry.py .
 COPY storage_api.py .
 COPY sheets_storage.py .
+COPY json_storage_core.py .
+COPY json_google_drive_storage.py .
+COPY transports/ transports/
 COPY templates/ templates/
 COPY static/ static/

--- a/app.py
+++ b/app.py
@@ -5,9 +5,9 @@ Sovereign Sandbox v2: Stateless Server + IndexedDB
 
 The server is stateless - it only handles:
 1. OAuth authentication with Google
-2. Proxying API calls to Google Sheets
+2. Proxying API calls to the active storage plugin (JSON on Drive, Google Sheets, etc.)
 
-All user data lives in the browser's IndexedDB and optionally in their Google Sheets.
+All user data lives in the browser's IndexedDB and optionally on the user's Google Drive.
 The server never stores any user pomodoro data.
 
 Credit: kirkjerk (localStorage approach idea, extended to IndexedDB)
@@ -30,13 +30,17 @@ from googleapiclient.errors import HttpError
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+import json_google_drive_storage
 import plugin_registry
 import sheets_storage
 import storage_api
 
 # Register built-in plugins
 plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLUGIN_METADATA)
-plugin_registry.activate_storage("sheets")
+plugin_registry.register(
+    "storage", "json-google-drive", json_google_drive_storage, json_google_drive_storage.PLUGIN_METADATA
+)
+plugin_registry.activate_storage("json-google-drive")
 
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
@@ -146,29 +150,43 @@ DEFAULT_SETTINGS = {
 DEFAULT_PORT = 5000
 
 
-def get_user_spreadsheet_mapping_path():
-    """Get path to the user-to-spreadsheet mapping file."""
-    return DATA_DIR / "user_spreadsheets.json"
+def _user_mapping_path():
+    """Get path to the user-to-storage-location mapping file."""
+    new_path = DATA_DIR / "user_storage.json"
+    if not new_path.exists():
+        legacy_path = DATA_DIR / "user_spreadsheets.json"
+        if legacy_path.exists():
+            legacy_path.rename(new_path)
+    return new_path
 
 
-def get_stored_spreadsheet_id(email):
-    """Get stored spreadsheet_id for a user email."""
-    mapping_path = get_user_spreadsheet_mapping_path()
+def get_stored_location(email, plugin_id):
+    """Get stored storage location for a user+plugin combination."""
+    mapping_path = _user_mapping_path()
     if mapping_path.exists():
         with open(mapping_path) as f:
             mapping = json.load(f)
-            return mapping.get(email)
+            user_entry = mapping.get(email, {})
+            if isinstance(user_entry, str):
+                # Legacy format: bare spreadsheet_id string
+                return user_entry if plugin_id == "sheets" else None
+            return user_entry.get(plugin_id)
     return None
 
 
-def save_spreadsheet_id(email, spreadsheet_id):
-    """Save spreadsheet_id for a user email."""
-    mapping_path = get_user_spreadsheet_mapping_path()
+def save_location(email, plugin_id, location_id):
+    """Save storage location for a user+plugin combination."""
+    mapping_path = _user_mapping_path()
     mapping = {}
     if mapping_path.exists():
         with open(mapping_path) as f:
             mapping = json.load(f)
-    mapping[email] = spreadsheet_id
+    user_entry = mapping.get(email, {})
+    if isinstance(user_entry, str):
+        # Migrate legacy format
+        user_entry = {"sheets": user_entry}
+    user_entry[plugin_id] = location_id
+    mapping[email] = user_entry
     with open(mapping_path, "w") as f:
         json.dump(mapping, f)
 
@@ -282,19 +300,26 @@ def _storage_context():
     backend = plugin_registry.get_active_storage()
     if backend is None:
         return None
-    service = get_sheets_service()
-    if not service:
+    credentials = get_credentials()
+    if not credentials:
         return None
-    location = get_spreadsheet_id_from_request()
-    if not location:
+    request_creds = get_credentials_from_request()
+    if not request_creds:
         return None
-    return {"service": service, "location": location}
+    return backend.build_context(credentials, request_creds)
 
 
 def is_logged_in():
     """Check if request has valid credentials (stateless)."""
     creds = get_credentials_from_request()
-    return creds is not None and creds.get("token") and creds.get("spreadsheet_id")
+    if not creds or not creds.get("token"):
+        return False
+    backend = plugin_registry.get_active_storage()
+    if backend is None:
+        return True
+    metadata = getattr(backend, "PLUGIN_METADATA", {})
+    required_fields = metadata.get("frontend_fields", [])
+    return all(creds.get(f) for f in required_fields)
 
 
 # =============================================================================
@@ -392,6 +417,75 @@ def _validate_oauth_callback():
     return state_data, code, None
 
 
+def _provision_sheets(credentials, user_email, requested_id):
+    """Provision a Google Sheets backend. Returns (spreadsheet_id, existed)."""
+    stored_id = get_stored_location(user_email, "sheets")
+    id_to_use = requested_id or stored_id
+
+    if id_to_use:
+        try:
+            sheets_service = build("sheets", "v4", credentials=credentials)
+            sheets_service.spreadsheets().get(spreadsheetId=id_to_use).execute()
+            save_location(user_email, "sheets", id_to_use)
+            return id_to_use, True
+        except HttpError:
+            id_to_use = None
+
+    if not id_to_use:
+        drive_service = build("drive", "v3", credentials=credentials)
+        spreadsheet = drive_service.files().create(
+            body={"name": "Acquacotta - Pomodoro Tracker", "mimeType": "application/vnd.google-apps.spreadsheet"},
+            fields="id",
+        ).execute()
+        new_id = spreadsheet["id"]
+        save_location(user_email, "sheets", new_id)
+
+        sheets_service = build("sheets", "v4", credentials=credentials)
+        sheets_service.spreadsheets().batchUpdate(
+            spreadsheetId=new_id,
+            body={"requests": [
+                {"updateSheetProperties": {"properties": {"sheetId": 0, "title": "Pomodoros"}, "fields": "title"}},
+                {"addSheet": {"properties": {"title": "Settings"}}},
+            ]},
+        ).execute()
+        sheets_service.spreadsheets().values().update(
+            spreadsheetId=new_id, range="Pomodoros!A1:G1", valueInputOption="RAW",
+            body={"values": [["id", "name", "type", "start_time", "end_time", "duration_minutes", "notes"]]},
+        ).execute()
+        sheets_service.spreadsheets().values().update(
+            spreadsheetId=new_id, range="Settings!A1:B1", valueInputOption="RAW",
+            body={"values": [["key", "value"]]},
+        ).execute()
+        return new_id, False
+
+    return id_to_use, True
+
+
+def _provision_json_google_drive(credentials, user_email, _requested_id):
+    """Provision a JSON-on-Google-Drive backend. Returns (folder_id, existed)."""
+    from transports.google_drive_transport import GoogleDriveTransport
+
+    stored_id = get_stored_location(user_email, "json-google-drive")
+    drive_service = build("drive", "v3", credentials=credentials)
+    transport = GoogleDriveTransport(drive_service, stored_id)
+    folder_id = transport.ensure_directory()
+    existed = stored_id == folder_id and stored_id is not None
+    save_location(user_email, "json-google-drive", folder_id)
+    return folder_id, existed
+
+
+def _provision_storage(plugin_id, credentials, user_email, requested_id):
+    """Provision the active storage backend. Returns (location_id, existed)."""
+    provisioners = {
+        "sheets": _provision_sheets,
+        "json-google-drive": _provision_json_google_drive,
+    }
+    provisioner = provisioners.get(plugin_id)
+    if not provisioner:
+        raise ValueError(f"No provisioner for storage plugin: {plugin_id}")
+    return provisioner(credentials, user_email, requested_id)
+
+
 @app.route("/auth/callback")
 def auth_callback():
     """Handle Google OAuth callback."""
@@ -453,85 +547,11 @@ def auth_callback():
         session["user_name"] = user_info.get("name")
         session["user_picture"] = user_info.get("picture")
 
-        # Priority: 1) User-provided spreadsheet ID, 2) Previously stored ID, 3) Create new
-        # requested_spreadsheet_id was already extracted from signed state_data above
-        stored_spreadsheet_id = get_stored_spreadsheet_id(user_email)
-
-        spreadsheet_id_to_use = requested_spreadsheet_id or stored_spreadsheet_id
-
-        if spreadsheet_id_to_use:
-            # Verify we can access this spreadsheet
-            # Note: Use credentials directly here since we're in OAuth callback, not using request-based auth
-            try:
-                sheets_service = build("sheets", "v4", credentials=credentials)
-                sheets_service.spreadsheets().get(spreadsheetId=spreadsheet_id_to_use).execute()
-                session["spreadsheet_id"] = spreadsheet_id_to_use
-                session["spreadsheet_existed"] = True
-                # Save/update the mapping for future logins
-                save_spreadsheet_id(user_email, spreadsheet_id_to_use)
-            except HttpError:
-                # Can't access spreadsheet (deleted, permissions changed, wrong ID)
-                spreadsheet_id_to_use = None
-
-        if not spreadsheet_id_to_use:
-            # Create new spreadsheet using Drive API (required for drive.file scope)
-            # Note: Use credentials directly here since we're in OAuth callback, not using request-based auth
-            drive_service = build("drive", "v3", credentials=credentials)
-            file_metadata = {
-                "name": "Acquacotta - Pomodoro Tracker",
-                "mimeType": "application/vnd.google-apps.spreadsheet",
-            }
-            spreadsheet = (
-                drive_service.files()
-                .create(
-                    body=file_metadata,
-                    fields="id",
-                )
-                .execute()
-            )
-            new_spreadsheet_id = spreadsheet["id"]
-            spreadsheet_existed = False
-
-            # Save the mapping for future logins
-            save_spreadsheet_id(user_email, new_spreadsheet_id)
-
-            # Now use Sheets API to set up the sheets (we have access since we created the file)
-            sheets_service = build("sheets", "v4", credentials=credentials)
-
-            # Rename default Sheet1 to Pomodoros and add Settings sheet
-            sheets_service.spreadsheets().batchUpdate(
-                spreadsheetId=new_spreadsheet_id,
-                body={
-                    "requests": [
-                        {
-                            "updateSheetProperties": {
-                                "properties": {"sheetId": 0, "title": "Pomodoros"},
-                                "fields": "title",
-                            }
-                        },
-                        {"addSheet": {"properties": {"title": "Settings"}}},
-                    ]
-                },
-            ).execute()
-
-            # Add headers to Pomodoros sheet
-            sheets_service.spreadsheets().values().update(
-                spreadsheetId=new_spreadsheet_id,
-                range="Pomodoros!A1:G1",
-                valueInputOption="RAW",
-                body={"values": [["id", "name", "type", "start_time", "end_time", "duration_minutes", "notes"]]},
-            ).execute()
-
-            # Add headers to Settings sheet
-            sheets_service.spreadsheets().values().update(
-                spreadsheetId=new_spreadsheet_id,
-                range="Settings!A1:B1",
-                valueInputOption="RAW",
-                body={"values": [["key", "value"]]},
-            ).execute()
-        else:
-            new_spreadsheet_id = spreadsheet_id_to_use
-            spreadsheet_existed = True
+        # Determine which storage plugin is active and provision accordingly
+        active_storage_id = plugin_registry.get_active_storage_id()
+        location_id, location_existed = _provision_storage(
+            active_storage_id, credentials, user_email, requested_spreadsheet_id
+        )
 
         # Build credentials data for frontend storage (AUTH store - ephemeral)
         credentials_data = {
@@ -547,13 +567,28 @@ def auth_callback():
         }
 
         # Settings data (SETTINGS store - persistent)
-        settings_data = {
-            "spreadsheet_id": new_spreadsheet_id,
-            "spreadsheet_existed": spreadsheet_existed,
-        }
+        # Write the plugin's frontend_fields so the browser sends them with API requests
+        backend = plugin_registry.get_active_storage()
+        metadata = getattr(backend, "PLUGIN_METADATA", {})
+        frontend_fields = metadata.get("frontend_fields", [])
+
+        settings_data = {"storage_existed": location_existed}
+        for field in frontend_fields:
+            settings_data[field] = location_id
 
         # Clear server session - credentials will live in browser IndexedDB
         session.clear()
+
+        # Build the JS that writes plugin-specific settings to IndexedDB
+        settings_js_lines = []
+        for field in frontend_fields:
+            settings_js_lines.append(
+                f"        settingsStore.put({{ key: '{field}', value: settings.{field}, synced: true }});"
+            )
+        settings_js_lines.append(
+            "        settingsStore.put({ key: 'storage_existed', value: settings.storage_existed, synced: true });"
+        )
+        settings_js = "\n".join(settings_js_lines)
 
         # Return HTML page that stores credentials in IndexedDB then redirects
         # Note: DB_VERSION must match storage.js (currently 2)
@@ -598,11 +633,10 @@ dbRequest.onsuccess = (e) => {{
     const authTx = db.transaction('auth', 'readwrite');
     authTx.objectStore('auth').put({{ key: 'credentials', ...credentials }});
     authTx.oncomplete = () => {{
-        // Store settings (persistent) - spreadsheet_id lives here
+        // Store plugin-specific settings (persistent)
         const settingsTx = db.transaction('settings', 'readwrite');
         const settingsStore = settingsTx.objectStore('settings');
-        settingsStore.put({{ key: 'spreadsheet_id', value: settings.spreadsheet_id, synced: true }});
-        settingsStore.put({{ key: 'spreadsheet_existed', value: settings.spreadsheet_existed, synced: true }});
+{settings_js}
         settingsTx.oncomplete = () => {{
             window.location.href = '/?view=settings';
         }};

--- a/app.py
+++ b/app.py
@@ -164,13 +164,15 @@ def get_stored_location(email, plugin_id):
     """Get stored storage location for a user+plugin combination."""
     mapping_path = _user_mapping_path()
     if mapping_path.exists():
-        with open(mapping_path) as f:
-            mapping = json.load(f)
-            user_entry = mapping.get(email, {})
-            if isinstance(user_entry, str):
-                # Legacy format: bare spreadsheet_id string
-                return user_entry if plugin_id == "sheets" else None
-            return user_entry.get(plugin_id)
+        try:
+            with open(mapping_path) as f:
+                mapping = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+        user_entry = mapping.get(email, {})
+        if isinstance(user_entry, str):
+            return user_entry if plugin_id == "sheets" else None
+        return user_entry.get(plugin_id)
     return None
 
 
@@ -179,11 +181,13 @@ def save_location(email, plugin_id, location_id):
     mapping_path = _user_mapping_path()
     mapping = {}
     if mapping_path.exists():
-        with open(mapping_path) as f:
-            mapping = json.load(f)
+        try:
+            with open(mapping_path) as f:
+                mapping = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            mapping = {}
     user_entry = mapping.get(email, {})
     if isinstance(user_entry, str):
-        # Migrate legacy format
         user_entry = {"sheets": user_entry}
     user_entry[plugin_id] = location_id
     mapping[email] = user_entry
@@ -466,9 +470,13 @@ def _provision_json_google_drive(credentials, user_email, _requested_id):
     from transports.google_drive_transport import GoogleDriveTransport
 
     stored_id = get_stored_location(user_email, "json-google-drive")
-    drive_service = build("drive", "v3", credentials=credentials)
-    transport = GoogleDriveTransport(drive_service, stored_id)
-    folder_id = transport.ensure_directory()
+    try:
+        drive_service = build("drive", "v3", credentials=credentials)
+        transport = GoogleDriveTransport(drive_service, stored_id)
+        folder_id = transport.ensure_directory()
+    except Exception as e:
+        app.logger.error(f"Failed to provision Google Drive storage: {e}")
+        raise
     existed = stored_id == folder_id and stored_id is not None
     save_location(user_email, "json-google-drive", folder_id)
     return folder_id, existed

--- a/app.py
+++ b/app.py
@@ -728,7 +728,7 @@ def update_spreadsheet():
     # Update session and persisted mapping
     session["spreadsheet_id"] = new_id
     if session.get("user_email"):
-        save_spreadsheet_id(session["user_email"], new_id)
+        save_location(session["user_email"], "sheets", new_id)
 
     return jsonify({"status": "ok", "spreadsheet_id": new_id})
 

--- a/app.py
+++ b/app.py
@@ -437,27 +437,37 @@ def _provision_sheets(credentials, user_email, requested_id):
 
     if not id_to_use:
         drive_service = build("drive", "v3", credentials=credentials)
-        spreadsheet = drive_service.files().create(
-            body={"name": "Acquacotta - Pomodoro Tracker", "mimeType": "application/vnd.google-apps.spreadsheet"},
-            fields="id",
-        ).execute()
+        spreadsheet = (
+            drive_service.files()
+            .create(
+                body={"name": "Acquacotta - Pomodoro Tracker", "mimeType": "application/vnd.google-apps.spreadsheet"},
+                fields="id",
+            )
+            .execute()
+        )
         new_id = spreadsheet["id"]
         save_location(user_email, "sheets", new_id)
 
         sheets_service = build("sheets", "v4", credentials=credentials)
         sheets_service.spreadsheets().batchUpdate(
             spreadsheetId=new_id,
-            body={"requests": [
-                {"updateSheetProperties": {"properties": {"sheetId": 0, "title": "Pomodoros"}, "fields": "title"}},
-                {"addSheet": {"properties": {"title": "Settings"}}},
-            ]},
+            body={
+                "requests": [
+                    {"updateSheetProperties": {"properties": {"sheetId": 0, "title": "Pomodoros"}, "fields": "title"}},
+                    {"addSheet": {"properties": {"title": "Settings"}}},
+                ]
+            },
         ).execute()
         sheets_service.spreadsheets().values().update(
-            spreadsheetId=new_id, range="Pomodoros!A1:G1", valueInputOption="RAW",
+            spreadsheetId=new_id,
+            range="Pomodoros!A1:G1",
+            valueInputOption="RAW",
             body={"values": [["id", "name", "type", "start_time", "end_time", "duration_minutes", "notes"]]},
         ).execute()
         sheets_service.spreadsheets().values().update(
-            spreadsheetId=new_id, range="Settings!A1:B1", valueInputOption="RAW",
+            spreadsheetId=new_id,
+            range="Settings!A1:B1",
+            valueInputOption="RAW",
             body={"values": [["key", "value"]]},
         ).execute()
         return new_id, False
@@ -741,11 +751,13 @@ def update_spreadsheet():
 @app.route("/api/plugins")
 def api_list_plugins():
     """List all registered plugins with their status."""
-    return jsonify({
-        "plugins": plugin_registry.list_plugins(),
-        "types": plugin_registry.list_plugin_types(),
-        "active_storage": plugin_registry.get_active_storage_id(),
-    })
+    return jsonify(
+        {
+            "plugins": plugin_registry.list_plugins(),
+            "types": plugin_registry.list_plugin_types(),
+            "active_storage": plugin_registry.get_active_storage_id(),
+        }
+    )
 
 
 @app.route("/api/plugins/toggle", methods=["POST"])
@@ -770,10 +782,12 @@ def api_toggle_plugin():
     else:
         return jsonify({"error": f"Toggle not yet supported for type: {plugin_type}"}), HTTPStatus.BAD_REQUEST
 
-    return jsonify({
-        "status": "ok",
-        "active_storage": plugin_registry.get_active_storage_id(),
-    })
+    return jsonify(
+        {
+            "status": "ok",
+            "active_storage": plugin_registry.get_active_storage_id(),
+        }
+    )
 
 
 # =============================================================================

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ import json_google_drive_storage
 import plugin_registry
 import sheets_storage
 import storage_api
+from storage_api import StorageUnavailable
 
 # Register built-in plugins
 plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLUGIN_METADATA)
@@ -271,15 +272,20 @@ def get_credentials():
             scopes=creds_data.get("scopes", []),
         )
 
-        # Refresh token if expired
-        if credentials.expired and credentials.refresh_token:
+        # Only attempt refresh if we have the necessary fields
+        if credentials.expired and credentials.refresh_token and credentials.client_id:
             from google.auth.transport.requests import Request
 
             credentials.refresh(Request())
 
         return credentials
     except Exception as e:
-        app.logger.error(f"Error creating credentials: {e}")
+        has_token = bool(creds_data.get("token"))
+        has_refresh = bool(creds_data.get("refresh_token"))
+        has_client = bool(creds_data.get("client_id"))
+        app.logger.error(
+            f"Error creating credentials: {e} (token={has_token}, refresh_token={has_refresh}, client_id={has_client})"
+        )
         return None
 
 
@@ -364,7 +370,7 @@ def auth_google():
         authorization_url, state = flow.authorization_url(
             access_type="offline",
             include_granted_scopes="true",
-            prompt="select_account",  # Fast login for returning users
+            prompt="consent",  # Always get refresh_token for stateless architecture
         )
 
         # Bundle PKCE code_verifier + CSRF nonce into a signed state parameter.
@@ -744,6 +750,51 @@ def update_spreadsheet():
 
 
 # =============================================================================
+# Storage Provisioning
+# =============================================================================
+
+
+@app.route("/api/storage/provision", methods=["POST"])
+def api_provision_storage():
+    """Provision the active storage backend using existing credentials.
+
+    Called automatically when the frontend detects a plugin switch — the user
+    has valid Google tokens but is missing the new plugin's location field
+    (e.g., has spreadsheet_id but not folder_id). This endpoint provisions the
+    new backend (creates the Drive folder, etc.) and returns the location fields
+    the frontend should store in IndexedDB.
+    """
+    credentials = get_credentials()
+    if not credentials:
+        return jsonify({"error": "Not authenticated"}), HTTPStatus.UNAUTHORIZED
+
+    request_creds = get_credentials_from_request()
+    user_email = request_creds.get("user_email") if request_creds else None
+    if not user_email:
+        return jsonify({"error": "No user email in credentials"}), HTTPStatus.BAD_REQUEST
+
+    active_id = plugin_registry.get_active_storage_id()
+    if not active_id:
+        return jsonify({"error": "No storage plugin active"}), HTTPStatus.BAD_REQUEST
+
+    try:
+        location_id, existed = _provision_storage(active_id, credentials, user_email, None)
+    except Exception as e:
+        app.logger.error(f"Storage provisioning failed: {e}")
+        return jsonify({"error": f"Provisioning failed: {e}"}), HTTPStatus.INTERNAL_SERVER_ERROR
+
+    backend = plugin_registry.get_active_storage()
+    metadata = getattr(backend, "PLUGIN_METADATA", {})
+    frontend_fields = metadata.get("frontend_fields", [])
+
+    result = {"status": "ok", "existed": existed, "plugin_id": active_id}
+    for field in frontend_fields:
+        result[field] = location_id
+
+    return jsonify(result)
+
+
+# =============================================================================
 # Plugin API
 # =============================================================================
 
@@ -822,7 +873,7 @@ def proxy_get_pomodoro_count():
         ctx = _storage_context()
         count = storage_api.count_pomodoros(ctx)
         return jsonify({"count": count})
-    except HttpError as e:
+    except (HttpError, StorageUnavailable) as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
 
 

--- a/json_google_drive_storage.py
+++ b/json_google_drive_storage.py
@@ -1,0 +1,132 @@
+"""JSON on Google Drive storage plugin for Acquacotta.
+
+Wires json_storage_core (shared logic) with google_drive_transport (Drive API).
+"""
+
+from googleapiclient.discovery import build
+
+import json_storage_core as core
+from transports.google_drive_transport import GoogleDriveTransport
+
+PLUGIN_METADATA = {
+    "id": "json-google-drive",
+    "name": "JSON on Google Drive",
+    "description": "Store data as JSON files on your Google Drive",
+    "version": "1.0.0",
+    "type": "storage",
+    "author": "crunchtools",
+    "frontend_fields": ["folder_id"],
+    "auth_flow": "google_oauth",
+}
+
+POMODOROS_FILE = "pomodoros.json"
+SETTINGS_FILE = "settings.json"
+
+
+def build_context(credentials, request_creds):
+    """Build Drive-specific storage context from credentials."""
+    service = build("drive", "v3", credentials=credentials)
+    return {
+        "service": service,
+        "location": request_creds.get("folder_id"),
+    }
+
+
+def _transport(drive_service, folder_id):
+    return GoogleDriveTransport(drive_service, folder_id)
+
+
+def get_pomodoros(drive_service, folder_id, start_date=None, end_date=None):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    return core.filter_by_date(pomodoros, start_date, end_date)
+
+
+def save_pomodoro(drive_service, folder_id, pomodoro):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    pomodoros, was_new = core.add_pomodoro(pomodoros, pomodoro)
+    if was_new:
+        t.upload_file(POMODOROS_FILE, core.serialize_pomodoros(pomodoros))
+    return was_new
+
+
+def save_pomodoros_batch(drive_service, folder_id, new_pomodoros):
+    if not new_pomodoros:
+        return 0
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    pomodoros, added = core.add_pomodoros_batch(pomodoros, new_pomodoros)
+    if added:
+        t.upload_file(POMODOROS_FILE, core.serialize_pomodoros(pomodoros))
+    return added
+
+
+def update_pomodoro(drive_service, folder_id, pomodoro_id, update_fields):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    pomodoros, found = core.update_pomodoro(pomodoros, pomodoro_id, update_fields)
+    if found:
+        t.upload_file(POMODOROS_FILE, core.serialize_pomodoros(pomodoros))
+    return found
+
+
+def delete_pomodoro(drive_service, folder_id, pomodoro_id):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    pomodoros, found = core.delete_pomodoro(pomodoros, pomodoro_id)
+    if found:
+        t.upload_file(POMODOROS_FILE, core.serialize_pomodoros(pomodoros))
+    return found
+
+
+def get_settings(drive_service, folder_id, defaults):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(SETTINGS_FILE)
+    stored = core.parse_settings(content)
+    merged = dict(defaults)
+    merged.update(stored)
+    return merged
+
+
+def save_settings(drive_service, folder_id, settings_data, replace_all=False):
+    t = _transport(drive_service, folder_id)
+    if replace_all:
+        t.upload_file(SETTINGS_FILE, core.serialize_settings(settings_data))
+        return
+
+    content = t.download_file(SETTINGS_FILE)
+    existing = core.parse_settings(content)
+    merged = core.merge_settings(existing, settings_data, replace_all=False)
+    t.upload_file(SETTINGS_FILE, core.serialize_settings(merged))
+
+
+def deduplicate_pomodoros(drive_service, folder_id):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    deduped, removed = core.deduplicate(pomodoros)
+    if removed:
+        t.upload_file(POMODOROS_FILE, core.serialize_pomodoros(deduped))
+    return {"removed": removed, "total": len(deduped)}
+
+
+def count_pomodoros(drive_service, folder_id):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    return len(pomodoros)
+
+
+def clear_pomodoros(drive_service, folder_id):
+    t = _transport(drive_service, folder_id)
+    content = t.download_file(POMODOROS_FILE)
+    pomodoros = core.parse_pomodoros(content)
+    count = len(pomodoros)
+    t.upload_file(POMODOROS_FILE, core.serialize_pomodoros([]))
+    return {"status": "ok", "cleared": count}

--- a/json_storage_core.py
+++ b/json_storage_core.py
@@ -1,0 +1,140 @@
+"""Acquacotta JSON Storage Core — transport-agnostic serialization, CRUD, and filtering.
+
+All functions operate on plain Python dicts/lists. They don't know or care
+where the JSON file lives — that's the transport's job.
+"""
+
+import json
+
+
+def parse_pomodoros(json_content):
+    """Parse JSON content into a list of pomodoro dicts.
+
+    Returns empty list on None, empty string, or invalid JSON.
+    """
+    if not json_content:
+        return []
+    try:
+        data = json.loads(json_content) if isinstance(json_content, str) else json_content
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if isinstance(data, dict):
+        return data.get("pomodoros", [])
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def serialize_pomodoros(pomodoros):
+    """Serialize pomodoro list to JSON string."""
+    return json.dumps({"pomodoros": pomodoros}, indent=2)
+
+
+def parse_settings(json_content):
+    """Parse JSON content into a settings dict."""
+    if not json_content:
+        return {}
+    try:
+        data = json.loads(json_content) if isinstance(json_content, str) else json_content
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def serialize_settings(settings):
+    """Serialize settings dict to JSON string."""
+    return json.dumps(settings, indent=2)
+
+
+def add_pomodoro(pomodoros, pomodoro):
+    """Add a pomodoro if its ID doesn't already exist.
+
+    Returns (updated_list, was_new).
+    """
+    pomodoro_id = pomodoro.get("id")
+    for existing in pomodoros:
+        if existing.get("id") == pomodoro_id:
+            return pomodoros, False
+
+    pomodoros.append(pomodoro)
+    return pomodoros, True
+
+
+def add_pomodoros_batch(pomodoros, new_pomodoros):
+    """Add multiple pomodoros, skipping duplicates.
+
+    Returns (updated_list, count_added).
+    """
+    existing_ids = {p.get("id") for p in pomodoros}
+    added = 0
+    for p in new_pomodoros:
+        if p.get("id") not in existing_ids:
+            pomodoros.append(p)
+            existing_ids.add(p.get("id"))
+            added += 1
+    return pomodoros, added
+
+
+def update_pomodoro(pomodoros, pomodoro_id, update_fields):
+    """Update a pomodoro by ID.
+
+    Returns (updated_list, was_found).
+    """
+    for p in pomodoros:
+        if p.get("id") == pomodoro_id:
+            for key, value in update_fields.items():
+                p[key] = value
+            return pomodoros, True
+    return pomodoros, False
+
+
+def delete_pomodoro(pomodoros, pomodoro_id):
+    """Delete a pomodoro by ID.
+
+    Returns (updated_list, was_found).
+    """
+    original_len = len(pomodoros)
+    pomodoros = [p for p in pomodoros if p.get("id") != pomodoro_id]
+    return pomodoros, len(pomodoros) < original_len
+
+
+def filter_by_date(pomodoros, start_date=None, end_date=None):
+    """Filter pomodoros by date range and sort descending by start_time."""
+    filtered = pomodoros
+    if start_date:
+        filtered = [p for p in filtered if p.get("start_time", "") >= start_date]
+    if end_date:
+        filtered = [p for p in filtered if p.get("start_time", "") <= end_date]
+    filtered.sort(key=lambda p: p.get("start_time", ""), reverse=True)
+    return filtered
+
+
+def deduplicate(pomodoros):
+    """Remove duplicate pomodoros (keeps first occurrence of each ID).
+
+    Returns (deduped_list, count_removed).
+    """
+    seen = set()
+    deduped = []
+    for p in pomodoros:
+        pid = p.get("id")
+        if pid not in seen:
+            seen.add(pid)
+            deduped.append(p)
+    removed = len(pomodoros) - len(deduped)
+    return deduped, removed
+
+
+def merge_settings(existing, updates, replace_all=False):
+    """Merge settings updates into existing settings.
+
+    If replace_all is True, return updates as the new settings.
+    Otherwise, overlay updates onto existing.
+    """
+    if replace_all:
+        return dict(updates)
+    merged = dict(existing)
+    merged.update(updates)
+    return merged

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -112,7 +112,7 @@ def list_plugins(plugin_type=None):
     for ptype in types_to_list:
         if ptype not in _plugins:
             continue
-        for pid, info in _plugins[ptype].items():
+        for _pid, info in _plugins[ptype].items():
             entry = dict(info["metadata"])
             entry["active"] = info["active"]
             entry["plugin_type"] = ptype

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -50,9 +50,7 @@ def register(plugin_type, plugin_id, module, metadata):
     contract = PLUGIN_TYPES[plugin_type]["contract"]
     missing = [fn for fn in contract if not callable(getattr(module, fn, None))]
     if missing:
-        raise ValueError(
-            f"Plugin '{plugin_id}' missing required functions: {', '.join(missing)}"
-        )
+        raise ValueError(f"Plugin '{plugin_id}' missing required functions: {', '.join(missing)}")
 
     if plugin_type not in _plugins:
         _plugins[plugin_type] = {}

--- a/sheets_storage.py
+++ b/sheets_storage.py
@@ -9,6 +9,8 @@ PLUGIN_METADATA = {
     "version": "1.0.0",
     "type": "storage",
     "author": "crunchtools",
+    "frontend_fields": ["spreadsheet_id"],
+    "auth_flow": "google_oauth",
 }
 
 # Column counts for Sheets data validation

--- a/sheets_storage.py
+++ b/sheets_storage.py
@@ -27,6 +27,8 @@ def build_context(credentials, request_creds):
         "service": service,
         "location": request_creds.get("spreadsheet_id"),
     }
+
+
 SETTINGS_MIN_COLUMNS = 2  # key, value
 
 
@@ -494,12 +496,7 @@ def clear_pomodoros(sheets_service, spreadsheet_id):
     if sheet_id is None:
         return {"status": "error", "error": "Pomodoros sheet not found", "cleared": 0}
 
-    values = (
-        sheets_service.spreadsheets()
-        .values()
-        .get(spreadsheetId=spreadsheet_id, range="Pomodoros!A:A")
-        .execute()
-    )
+    values = sheets_service.spreadsheets().values().get(spreadsheetId=spreadsheet_id, range="Pomodoros!A:A").execute()
     row_count = len(values.get("values", []))
 
     if row_count <= 1:

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -67,11 +67,15 @@
     const SYNC_RETRY_DELAYS = [1000, 2000, 5000, 10000, 30000]; // Exponential backoff
     const MAX_SYNC_RETRIES = 5;
 
+    // Storage location field names — each plugin declares its own in PLUGIN_METADATA.frontend_fields
+    const LOCATION_FIELDS = ['spreadsheet_id', 'folder_id'];
+
     // Storage state
     let db = null;
     let authStatus = null;
     let storedCredentials = null;  // OAuth credentials from IndexedDB (ephemeral)
-    let cachedSpreadsheetId = null;  // Spreadsheet ID from SETTINGS (persistent)
+    let cachedSpreadsheetId = null;  // Legacy alias — kept for backwards compat
+    let cachedLocationFields = {};   // All plugin location fields from SETTINGS
     let isOnline = navigator.onLine;
     let syncInProgress = false;
     let syncLockPromise = null;  // Promise-based lock to prevent race conditions
@@ -235,43 +239,39 @@
      * Make authenticated API call with stored credentials
      * Spreadsheet ID comes from SETTINGS (persistent), credentials from AUTH (ephemeral)
      */
+    function _buildCredentialsPayload() {
+        const payload = {
+            token: storedCredentials.token,
+            refresh_token: storedCredentials.refresh_token,
+            token_uri: storedCredentials.token_uri,
+            client_id: storedCredentials.client_id,
+            client_secret: storedCredentials.client_secret,
+            scopes: storedCredentials.scopes,
+        };
+        // Include all cached location fields (spreadsheet_id, folder_id, etc.)
+        Object.assign(payload, cachedLocationFields);
+        return payload;
+    }
+
     async function authenticatedFetch(url, options = {}) {
         if (!storedCredentials) {
             throw new Error('Not logged in');
         }
-        if (!cachedSpreadsheetId) {
-            throw new Error('No spreadsheet configured');
+        const hasLocation = Object.values(cachedLocationFields).some(v => v);
+        if (!hasLocation) {
+            throw new Error('No storage location configured');
         }
 
-        // Add credentials to request body for POST/PUT, or as header for GET/DELETE
         const method = (options.method || 'GET').toUpperCase();
 
         if (method === 'GET' || method === 'DELETE') {
-            // For GET/DELETE, send credentials as Authorization header (base64 encoded JSON)
             options.headers = options.headers || {};
-            options.headers['X-Credentials'] = btoa(JSON.stringify({
-                token: storedCredentials.token,
-                refresh_token: storedCredentials.refresh_token,
-                token_uri: storedCredentials.token_uri,
-                client_id: storedCredentials.client_id,
-                client_secret: storedCredentials.client_secret,
-                scopes: storedCredentials.scopes,
-                spreadsheet_id: cachedSpreadsheetId
-            }));
+            options.headers['X-Credentials'] = btoa(JSON.stringify(_buildCredentialsPayload()));
         } else {
-            // For POST/PUT, merge credentials into body
             options.headers = options.headers || {};
             options.headers['Content-Type'] = 'application/json';
             const body = options.body ? JSON.parse(options.body) : {};
-            body._credentials = {
-                token: storedCredentials.token,
-                refresh_token: storedCredentials.refresh_token,
-                token_uri: storedCredentials.token_uri,
-                client_id: storedCredentials.client_id,
-                client_secret: storedCredentials.client_secret,
-                scopes: storedCredentials.scopes,
-                spreadsheet_id: cachedSpreadsheetId
-            };
+            body._credentials = _buildCredentialsPayload();
             options.body = JSON.stringify(body);
         }
 
@@ -605,13 +605,11 @@
                 await putInStore(STORES.SETTINGS, { key, value, synced: true });
             }
 
-            // Preserve spreadsheet_id in SETTINGS (it's not in Sheet, it's the ID of the Sheet itself)
-            if (cachedSpreadsheetId) {
-                await putInStore(STORES.SETTINGS, {
-                    key: 'spreadsheet_id',
-                    value: cachedSpreadsheetId,
-                    synced: true
-                });
+            // Preserve storage location fields (they're not in the backend data)
+            for (const [field, value] of Object.entries(cachedLocationFields)) {
+                if (value) {
+                    await putInStore(STORES.SETTINGS, { key: field, value, synced: true });
+                }
             }
 
             // Update last sync time
@@ -646,23 +644,31 @@
             // Load credentials from AUTH store (ephemeral - OAuth tokens only)
             const creds = await loadCredentials();
 
-            // Load spreadsheet_id from SETTINGS store (persistent)
-            const spreadsheetIdSetting = await getFromStore(STORES.SETTINGS, 'spreadsheet_id');
-            cachedSpreadsheetId = spreadsheetIdSetting ? spreadsheetIdSetting.value : null;
+            // Load all storage location fields from SETTINGS store (persistent)
+            cachedLocationFields = {};
+            for (const field of LOCATION_FIELDS) {
+                const setting = await getFromStore(STORES.SETTINGS, field);
+                if (setting && setting.value) {
+                    cachedLocationFields[field] = setting.value;
+                }
+            }
+            // Legacy alias for backwards compat
+            cachedSpreadsheetId = cachedLocationFields.spreadsheet_id || null;
 
-            // Load spreadsheet_existed from SETTINGS store
-            const spreadsheetExistedSetting = await getFromStore(STORES.SETTINGS, 'spreadsheet_existed');
-            const spreadsheetExisted = spreadsheetExistedSetting ? spreadsheetExistedSetting.value : false;
+            // Load storage_existed from SETTINGS store
+            const storageExistedSetting = await getFromStore(STORES.SETTINGS, 'storage_existed');
+            const storageExisted = storageExistedSetting ? storageExistedSetting.value : false;
 
-            // Build auth status from credentials (AUTH) + spreadsheet_id (SETTINGS)
-            if (creds && creds.token && cachedSpreadsheetId) {
+            // Build auth status from credentials (AUTH) + location fields (SETTINGS)
+            const hasLocation = Object.values(cachedLocationFields).some(v => v);
+            if (creds && creds.token && hasLocation) {
                 authStatus = {
                     logged_in: true,
                     email: creds.user_email,
                     name: creds.user_name,
                     picture: creds.user_picture,
                     spreadsheet_id: cachedSpreadsheetId,
-                    needs_initial_sync: !spreadsheetExisted
+                    needs_initial_sync: !storageExisted
                 };
             } else {
                 authStatus = {
@@ -733,19 +739,19 @@
                                 for (const [key, value] of Object.entries(sheetsSettings)) {
                                     await putInStore(STORES.SETTINGS, { key, value, synced: true });
                                 }
-                                // Re-save spreadsheet_id after clearing
-                                await putInStore(STORES.SETTINGS, {
-                                    key: 'spreadsheet_id',
-                                    value: cachedSpreadsheetId,
-                                    synced: true
-                                });
+                                // Re-save location fields after clearing
+                                for (const [field, value] of Object.entries(cachedLocationFields)) {
+                                    if (value) {
+                                        await putInStore(STORES.SETTINGS, { key: field, value, synced: true });
+                                    }
+                                }
                             }
                         }
                         await putInStore(STORES.SYNC_STATUS, { key: 'initial_sync_done', value: true });
                     }
 
-                    // Mark spreadsheet as existing
-                    await putInStore(STORES.SETTINGS, { key: 'spreadsheet_existed', value: true, synced: true });
+                    // Mark storage as existing
+                    await putInStore(STORES.SETTINGS, { key: 'storage_existed', value: true, synced: true });
 
                     // Process any queued pushes
                     await processSyncQueue();
@@ -826,28 +832,24 @@
         },
 
         /**
-         * Update spreadsheet ID in IndexedDB (SETTINGS store only)
+         * Update a storage location field in IndexedDB (SETTINGS store only)
+         * @param {string} field - Field name (e.g., 'spreadsheet_id', 'folder_id')
+         * @param {string} newId - New location ID
+         * @returns {Promise}
+         */
+        updateLocationField: async function(field, newId) {
+            await putInStore(STORES.SETTINGS, { key: field, value: newId, synced: false });
+            cachedLocationFields[field] = newId;
+            if (field === 'spreadsheet_id') cachedSpreadsheetId = newId;
+        },
+
+        /**
+         * Update spreadsheet ID in IndexedDB (legacy compat wrapper)
          * @param {string} newId - New spreadsheet ID
          * @returns {Promise}
          */
         updateSpreadsheetId: async function(newId) {
-            // Update SETTINGS store (persistent)
-            await putInStore(STORES.SETTINGS, {
-                key: 'spreadsheet_id',
-                value: newId,
-                synced: false
-            });
-
-            // Update cached value for current session
-            cachedSpreadsheetId = newId;
-
-            // Queue sync to save spreadsheet_id to Google Sheets Settings
-            await addToSyncQueue('update', 'settings', 'spreadsheet_id', {
-                spreadsheet_id: newId
-            });
-
-            // Process the queue
-            await processSyncQueue();
+            await this.updateLocationField('spreadsheet_id', newId);
         },
 
         /**

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -78,6 +78,7 @@
     let cachedLocationFields = {};   // All plugin location fields from SETTINGS
     let isOnline = navigator.onLine;
     let syncInProgress = false;
+    let cachedActivePlugin = null; // Active storage plugin metadata from /api/plugins
     let syncLockPromise = null;  // Promise-based lock to prevent race conditions
     let pendingSyncCount = 0;
     let lastSyncError = null;
@@ -275,6 +276,10 @@
             options.body = JSON.stringify(body);
         }
 
+        return fetch(url, options);
+    }
+
+    function authenticatedFetchRaw(url, options = {}) {
         return fetch(url, options);
     }
 
@@ -659,17 +664,91 @@
             const storageExistedSetting = await getFromStore(STORES.SETTINGS, 'storage_existed');
             const storageExisted = storageExistedSetting ? storageExistedSetting.value : false;
 
-            // Build auth status from credentials (AUTH) + location fields (SETTINGS)
-            const hasLocation = Object.values(cachedLocationFields).some(v => v);
-            if (creds && creds.token && hasLocation) {
+            // Fetch active plugin info to know which location fields are required
+            try {
+                const pluginRes = await fetch('/api/plugins');
+                if (pluginRes.ok) {
+                    const pluginData = await pluginRes.json();
+                    cachedActivePlugin = pluginData.plugins.find(p => p.active && p.plugin_type === 'storage') || null;
+                }
+            } catch (e) { /* offline — fall back to checking any location field */ }
+            const activePlugin = cachedActivePlugin;
+
+            const requiredFields = activePlugin ? (activePlugin.frontend_fields || []) : [];
+            const hasRequiredLocation = requiredFields.length === 0 ||
+                requiredFields.some(f => cachedLocationFields[f]);
+            const hasAnyCreds = creds && creds.token;
+
+            if (hasAnyCreds && hasRequiredLocation) {
                 authStatus = {
                     logged_in: true,
                     email: creds.user_email,
                     name: creds.user_name,
                     picture: creds.user_picture,
                     spreadsheet_id: cachedSpreadsheetId,
-                    needs_initial_sync: !storageExisted
+                    folder_id: cachedLocationFields.folder_id || null,
+                    needs_initial_sync: !storageExisted,
+                    needs_relogin: false
                 };
+            } else if (hasAnyCreds && !hasRequiredLocation) {
+                // Plugin changed — auto-provision the new backend with existing credentials.
+                // Clear stale sync queue (it was for the old plugin).
+                await clearStore(STORES.SYNC_QUEUE);
+
+                let provisioned = false;
+                try {
+                    const provRes = await authenticatedFetchRaw('/api/storage/provision', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            _credentials: {
+                                token: creds.token,
+                                refresh_token: creds.refresh_token,
+                                token_uri: creds.token_uri,
+                                client_id: creds.client_id,
+                                client_secret: creds.client_secret,
+                                scopes: creds.scopes,
+                                user_email: creds.user_email,
+                            }
+                        })
+                    });
+                    if (provRes.ok) {
+                        const provData = await provRes.json();
+                        for (const field of requiredFields) {
+                            if (provData[field]) {
+                                cachedLocationFields[field] = provData[field];
+                                await putInStore(STORES.SETTINGS, { key: field, value: provData[field], synced: true });
+                            }
+                        }
+                        cachedSpreadsheetId = cachedLocationFields.spreadsheet_id || null;
+                        await putInStore(STORES.SETTINGS, { key: 'storage_existed', value: provData.existed, synced: true });
+                        provisioned = true;
+                    }
+                } catch (e) {
+                    console.error('Auto-provision failed:', e);
+                }
+
+                if (provisioned) {
+                    authStatus = {
+                        logged_in: true,
+                        email: creds.user_email,
+                        name: creds.user_name,
+                        picture: creds.user_picture,
+                        spreadsheet_id: cachedSpreadsheetId,
+                        folder_id: cachedLocationFields.folder_id || null,
+                        needs_initial_sync: true,
+                        needs_relogin: false
+                    };
+                } else {
+                    authStatus = {
+                        logged_in: false,
+                        needs_relogin: true,
+                        google_configured: true,
+                        relogin_reason: activePlugin
+                            ? `Could not set up ${activePlugin.name}. Please sign in again.`
+                            : 'Please sign in again'
+                    };
+                }
             } else {
                 authStatus = {
                     logged_in: false,
@@ -698,7 +777,10 @@
             // Bidirectional sync on every page load when logged in
             if (authStatus.logged_in && storedCredentials) {
                 try {
-                    // 1. Fetch pomodoros from Sheets
+                    // Clear any stale sync queue — the batch push below handles everything
+                    await clearStore(STORES.SYNC_QUEUE);
+
+                    // 1. Fetch pomodoros from backend
                     const pomosRes = await authenticatedFetch('/api/sheets/pomodoros');
                     if (pomosRes.ok) {
                         const sheetsPomodoros = await pomosRes.json();
@@ -716,14 +798,26 @@
                             }
                         }
 
-                        // 4. Push local pomodoros to Sheets that don't exist there
+                        // 4. Push local pomodoros that don't exist on the backend
+                        const toPush = [];
                         for (const pomo of localPomodoros) {
                             if (!sheetsIds.has(pomo.id)) {
-                                await addToSyncQueue('create', 'pomodoros', pomo.id, pomo);
+                                toPush.push(pomo);
                             } else {
-                                // Mark as synced since it exists in Sheets
                                 pomo.synced = true;
                                 await putInStore(STORES.POMODOROS, pomo);
+                            }
+                        }
+                        if (toPush.length > 0) {
+                            const batchRes = await authenticatedFetch('/api/sheets/pomodoros/batch', {
+                                method: 'POST',
+                                body: JSON.stringify({ pomodoros: toPush })
+                            });
+                            if (batchRes.ok) {
+                                for (const pomo of toPush) {
+                                    pomo.synced = true;
+                                    await putInStore(STORES.POMODOROS, pomo);
+                                }
                             }
                         }
                     }
@@ -752,9 +846,6 @@
 
                     // Mark storage as existing
                     await putInStore(STORES.SETTINGS, { key: 'storage_existed', value: true, synced: true });
-
-                    // Process any queued pushes
-                    await processSyncQueue();
                 } catch (e) {
                     console.error('Bidirectional sync during init failed:', e);
                 }
@@ -775,6 +866,10 @@
          */
         getAuthStatus: function() {
             return authStatus;
+        },
+
+        getActivePlugin: function() {
+            return cachedActivePlugin;
         },
 
         /**

--- a/storage_api.py
+++ b/storage_api.py
@@ -1,18 +1,10 @@
 """Acquacotta Storage API — dispatch layer for storage backend plugins."""
 
-from googleapiclient.errors import HttpError
-
 import plugin_registry
 
 
-class StorageUnavailable(HttpError):
+class StorageUnavailable(Exception):
     """Raised when no storage backend is active or context is missing."""
-
-    def __init__(self):
-        super().__init__(
-            resp=type("resp", (), {"status": 503, "reason": "No storage backend active"})(),
-            content=b"No storage backend active",
-        )
 
 
 def _require_context(ctx):

--- a/templates/index.html
+++ b/templates/index.html
@@ -480,8 +480,8 @@
             clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
         }
     </style>
-    <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/storage.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/utils.js') }}?v=3"></script>
+    <script src="{{ url_for('static', filename='js/storage.js') }}?v=3"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -681,12 +681,12 @@
         <div id="settings-view" class="view" role="tabpanel" aria-labelledby="tab-settings">
             <h2>Settings</h2>
             <div class="card" id="google-account-card">
-                <h3>Google Sheets Sync (Optional)</h3>
+                <h3 id="cloud-sync-title">Cloud Sync (Optional)</h3>
                 <div id="google-logged-out">
                     <p style="color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 1rem;">
-                        Your data is stored locally by default. Optionally sign in with Google to sync your data to Google Sheets.
+                        Your data is stored locally by default. Optionally sign in with Google to sync your data to your Google Drive.
                     </p>
-                    <div style="margin-bottom: 1rem;">
+                    <div id="login-spreadsheet-section" style="margin-bottom: 1rem; display: none;">
                         <label for="login-spreadsheet-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Existing Spreadsheet ID (optional):</label>
                         <input type="text" id="login-spreadsheet-id" style="width: 24rem; max-width: 100%; font-family: monospace; font-size: 0.75rem; padding: 0.5rem;" placeholder="Leave blank to create new">
                         <p style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
@@ -708,23 +708,25 @@
                             <div id="google-email" style="font-size: 0.875rem; color: var(--text-secondary);"></div>
                         </div>
                     </div>
-                    <p style="color: var(--success); font-size: 0.875rem; margin-bottom: 1rem;">
-                        ✓ Data synced to Google Sheets
+                    <p id="cloud-sync-status-text" style="color: var(--success); font-size: 0.875rem; margin-bottom: 1rem;">
+                        ✓ Data synced to Google Drive
                     </p>
                     <div style="margin-bottom: 1rem;">
                         <span style="font-size: 0.875rem; color: var(--text-secondary);">Pomodoros stored: </span>
                         <span id="google-pomodoro-count" style="font-weight: 500; color: var(--accent);">0</span>
                     </div>
-                    <label for="spreadsheet-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Spreadsheet ID:</label>
-                    <div style="display: inline-grid; grid-template-columns: 1fr auto; gap: 0.5rem; margin-bottom: 1rem;">
-                        <input type="text" id="spreadsheet-id" style="width: 100%; font-family: monospace; font-size: 0.75rem; padding: 0.5rem; box-sizing: border-box;" placeholder="Spreadsheet ID">
-                        <button class="secondary" onclick="updateSpreadsheetId()" style="text-align: center;">Update</button>
-                        <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                            <button class="secondary" id="sync-button" onclick="manualSync()">Sync Now</button>
-                            <button class="secondary" onclick="confirmOverwriteLocal()">Overwrite Local</button>
-                            <button class="secondary" onclick="confirmOverwriteGoogle()">Overwrite Google</button>
+                    <div id="location-field-section">
+                        <label id="location-field-label" for="storage-location-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Storage Location:</label>
+                        <div style="display: inline-grid; grid-template-columns: 1fr auto; gap: 0.5rem; margin-bottom: 1rem;">
+                            <input type="text" id="storage-location-id" style="width: 100%; font-family: monospace; font-size: 0.75rem; padding: 0.5rem; box-sizing: border-box;" placeholder="Location ID" readonly>
+                            <button id="storage-open-link" class="secondary" style="display: none; text-align: center;" onclick="window.open(this.dataset.href, '_blank')">Open</button>
+                            <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                                <button class="secondary" id="sync-button" onclick="manualSync()">Sync Now</button>
+                                <button class="secondary" onclick="confirmOverwriteLocal()">Overwrite Local</button>
+                                <button class="secondary" onclick="confirmOverwriteGoogle()">Overwrite Google</button>
+                            </div>
+                            <button class="secondary" onclick="logoutFromGoogle()" style="text-align: center;">Sign Out</button>
                         </div>
-                        <button class="secondary" onclick="logoutFromGoogle()" style="text-align: center;">Sign Out</button>
                     </div>
                     <p id="spreadsheet-id-status" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: -0.5rem; margin-bottom: 0.5rem; display: none;"></p>
                     <p id="migrate-status" style="font-size: 0.875rem; margin-top: 0.5rem; display: none;"></p>
@@ -3969,43 +3971,38 @@
                 console.error('Failed to check auth config:', e);
             }
 
-            // Initialize Storage - this loads credentials from IndexedDB
-            await Storage.init({ google_configured: googleConfigured });
+            // Initialize Storage - this loads credentials from IndexedDB and plugin info
+            try {
+                await Storage.init({ google_configured: googleConfigured });
+            } catch (e) {
+                console.error('Storage init failed:', e);
+            }
 
-            // Get auth status from Storage (based on IndexedDB credentials)
+            // Get auth status and plugin info from Storage
             authStatus = Storage.getAuthStatus();
+            activePluginInfo = Storage.getActivePlugin();
 
             // Migrate any data from old localStorage to IndexedDB
-            await Storage.migrateFromLocalStorage();
-
-            // Auto-fill spreadsheet ID if user has one stored (for re-login)
-            if (!authStatus.logged_in) {
-                const storedSpreadsheetId = await Storage.getStoredSpreadsheetId();
-                if (storedSpreadsheetId) {
-                    const input = document.getElementById('login-spreadsheet-id');
-                    if (input) {
-                        input.value = storedSpreadsheetId;
-                    }
-                }
-            }
+            try { await Storage.migrateFromLocalStorage(); } catch (e) { console.error('Migration error:', e); }
 
             updateAuthUI();
             await updateStorageIndicator();
 
             if (authStatus.logged_in) {
-                // Auto-sync pending items silently (no prompt needed)
-                const syncStatus = Storage.getSyncStatus();
-                if (syncStatus.pending > 0) {
-                    await Storage.syncToSheets();
-                }
-
-                // If needs initial sync, sync from Sheets to IndexedDB
-                if (authStatus.needs_initial_sync) {
-                    await showInitialSyncModal();
+                try {
+                    const syncStatus = Storage.getSyncStatus();
+                    if (syncStatus.pending > 0) {
+                        await Storage.syncToSheets();
+                    }
+                    if (authStatus.needs_initial_sync) {
+                        await showInitialSyncModal();
+                    }
+                } catch (e) {
+                    console.error('Sync error:', e);
                 }
             }
 
-            // Always load settings (from IndexedDB)
+            // Always load settings and plugins (independent of auth)
             await loadSettings();
         }
 
@@ -4039,7 +4036,7 @@
                     modeText.textContent = syncStatus.pending > 0
                         ? `Syncing (${syncStatus.pending})`
                         : 'Syncing...';
-                    indicator.title = 'Syncing with Google Sheets';
+                    indicator.title = 'Syncing with ' + (activePluginInfo ? activePluginInfo.name : 'cloud');
                 } else if (syncStatus.error) {
                     indicatorDot.style.background = '#ef4444'; // Red for error
                     modeText.textContent = 'Sync Error';
@@ -4047,7 +4044,7 @@
                 } else {
                     indicatorDot.style.background = '#4ecca3'; // Green for synced
                     modeText.textContent = 'Synced';
-                    indicator.title = 'Data is synced to Google Sheets';
+                    indicator.title = 'Data is synced to ' + (activePluginInfo ? activePluginInfo.name : 'cloud');
                 }
 
                 localDataCard.style.display = 'block';
@@ -4500,18 +4497,58 @@
             }
         }
 
+        let activePluginInfo = null;
+
         function updateAuthUI() {
             const loggedOut = document.getElementById('google-logged-out');
             const loggedIn = document.getElementById('google-logged-in');
             const loginBtn = document.getElementById('google-login-btn');
             const notConfigured = document.getElementById('google-not-configured');
 
+            const isJsonDrive = activePluginInfo && activePluginInfo.id === 'json-google-drive';
+            const isSheets = !activePluginInfo || activePluginInfo.id === 'sheets';
+            const pluginName = activePluginInfo ? activePluginInfo.name : 'Google Sheets';
+
+            // Update card title and sync status text
+            document.getElementById('cloud-sync-title').textContent = pluginName + ' Sync (Optional)';
+            document.getElementById('cloud-sync-status-text').textContent = '✓ Data synced to ' + pluginName;
+
+            // Show spreadsheet ID input on login only for Sheets plugin
+            const loginSpreadsheetSection = document.getElementById('login-spreadsheet-section');
+            if (loginSpreadsheetSection) {
+                loginSpreadsheetSection.style.display = isSheets ? 'block' : 'none';
+            }
+
             if (authStatus.logged_in) {
                 loggedOut.style.display = 'none';
                 loggedIn.style.display = 'block';
                 document.getElementById('google-name').textContent = authStatus.name || '';
                 document.getElementById('google-email').textContent = authStatus.email || '';
-                document.getElementById('spreadsheet-id').value = authStatus.spreadsheet_id || '';
+
+                // Show the appropriate location field and "Open" link
+                const locationInput = document.getElementById('storage-location-id');
+                const locationLabel = document.getElementById('location-field-label');
+                const openLink = document.getElementById('storage-open-link');
+                if (isJsonDrive) {
+                    locationLabel.textContent = 'Drive Folder ID:';
+                    locationInput.value = authStatus.folder_id || '';
+                    if (authStatus.folder_id) {
+                        openLink.dataset.href = 'https://drive.google.com/drive/folders/' + authStatus.folder_id;
+                        openLink.style.display = 'inline';
+                    } else {
+                        openLink.style.display = 'none';
+                    }
+                } else {
+                    locationLabel.textContent = 'Spreadsheet ID:';
+                    locationInput.value = authStatus.spreadsheet_id || '';
+                    if (authStatus.spreadsheet_id) {
+                        openLink.dataset.href = 'https://docs.google.com/spreadsheets/d/' + authStatus.spreadsheet_id;
+                        openLink.style.display = 'inline';
+                    } else {
+                        openLink.style.display = 'none';
+                    }
+                }
+
                 const avatarEl = document.getElementById('google-avatar');
                 if (authStatus.picture) {
                     avatarEl.src = authStatus.picture;
@@ -4519,12 +4556,16 @@
                 } else {
                     avatarEl.style.display = 'none';
                 }
-                // Update Google pomodoro count
                 updateGooglePomodoroCount();
             } else {
                 loggedOut.style.display = 'block';
                 loggedIn.style.display = 'none';
-                if (!authStatus.google_configured) {
+                if (authStatus.needs_relogin) {
+                    const reloginMsg = document.getElementById('google-not-configured');
+                    reloginMsg.textContent = authStatus.relogin_reason;
+                    reloginMsg.style.display = 'block';
+                    reloginMsg.style.color = 'var(--accent)';
+                } else if (!authStatus.google_configured) {
                     loginBtn.disabled = true;
                     loginBtn.style.opacity = '0.5';
                     notConfigured.style.display = 'block';
@@ -4594,7 +4635,8 @@
 
         async function confirmOverwriteGoogle() {
             const localCount = await Storage.getLocalPomodoroCount();
-            if (!confirm(`This will REPLACE all data in Google Sheets with your ${localCount} local pomodoros.\n\nThis cannot be undone. Continue?`)) {
+            const backendName = activePluginInfo ? activePluginInfo.name : 'cloud storage';
+            if (!confirm(`This will REPLACE all data in ${backendName} with your ${localCount} local pomodoros.\n\nThis cannot be undone. Continue?`)) {
                 return;
             }
             await overwriteGoogle();
@@ -4602,25 +4644,25 @@
 
         async function overwriteGoogle() {
             const statusEl = document.getElementById('migrate-status');
+            const backendName = activePluginInfo ? activePluginInfo.name : 'cloud';
             statusEl.style.display = 'block';
             statusEl.style.color = 'var(--text-secondary)';
-            statusEl.textContent = 'Clearing Google Sheets...';
+            statusEl.textContent = 'Clearing ' + backendName + '...';
 
             try {
-                // Clear all pomodoro rows in Sheets
                 const clearRes = await Storage.authenticatedFetch('/api/sheets/clear', { method: 'POST' });
-                if (!clearRes.ok) throw new Error('Failed to clear Sheets');
+                if (!clearRes.ok) {
+                    const errData = await clearRes.json().catch(() => ({}));
+                    throw new Error(errData.error || 'Failed to clear cloud storage');
+                }
 
-                statusEl.textContent = 'Uploading local data to Google Sheets...';
+                statusEl.textContent = 'Uploading local data...';
 
-                // Upload all local pomodoros (batch)
                 const result = await Storage.migrateLocalToBackend();
-
-                // Replace all settings in Sheet with local IndexedDB settings
                 await Storage.migrateLocalSettingsToBackend(true);
 
                 statusEl.style.color = 'var(--success)';
-                statusEl.textContent = `✓ Replaced Google Sheets with ${result.migrated || 0} pomodoros`;
+                statusEl.textContent = `✓ Replaced ${backendName} with ${result.migrated || 0} pomodoros`;
 
                 await updateStorageIndicator();
             } catch (e) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def authenticated_session(app):
         "client_secret": "fake-client-secret",
         "scopes": ["https://www.googleapis.com/auth/drive.file"],
         "spreadsheet_id": "fake-spreadsheet-id",
+        "folder_id": "fake-folder-id",
     }
 
     with app.test_client() as client:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -184,11 +184,13 @@ class TestPluginsAPI:
         assert "plugins" in data
         assert "types" in data
         assert "active_storage" in data
-        assert data["active_storage"] == "sheets"
+        assert data["active_storage"] == "json-google-drive"
+        json_plugin = next(p for p in data["plugins"] if p["id"] == "json-google-drive")
+        assert json_plugin["name"] == "JSON on Google Drive"
+        assert json_plugin["plugin_type"] == "storage"
+        assert json_plugin["active"] is True
         sheets_plugin = next(p for p in data["plugins"] if p["id"] == "sheets")
-        assert sheets_plugin["name"] == "Google Sheets"
-        assert sheets_plugin["plugin_type"] == "storage"
-        assert sheets_plugin["active"] is True
+        assert sheets_plugin["active"] is False
 
 
 class TestClearInitialSync:

--- a/tests/test_json_google_drive.py
+++ b/tests/test_json_google_drive.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 import json_google_drive_storage as storage
 from transports.google_drive_transport import GoogleDriveTransport
 
-
 # =============================================================================
 # Transport tests
 # =============================================================================
@@ -143,10 +142,14 @@ def _mock_transport(file_contents=None):
 class TestGetPomodoros:
     @patch("json_google_drive_storage._transport")
     def test_returns_pomodoros(self, mock_transport_fn):
-        data = json.dumps({"pomodoros": [
-            {"id": "1", "start_time": "2026-01-15T10:00:00Z"},
-            {"id": "2", "start_time": "2026-01-20T10:00:00Z"},
-        ]})
+        data = json.dumps(
+            {
+                "pomodoros": [
+                    {"id": "1", "start_time": "2026-01-15T10:00:00Z"},
+                    {"id": "2", "start_time": "2026-01-20T10:00:00Z"},
+                ]
+            }
+        )
         mock_transport_fn.return_value = _mock_transport(data)
         result = storage.get_pomodoros("svc", "folder", start_date="2026-01-16")
         assert len(result) == 1

--- a/tests/test_json_google_drive.py
+++ b/tests/test_json_google_drive.py
@@ -1,0 +1,320 @@
+"""Tests for json_google_drive_storage.py and google_drive_transport.py.
+
+Tests the storage plugin contract and transport layer using mocked Drive API.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import json_google_drive_storage as storage
+from transports.google_drive_transport import GoogleDriveTransport
+
+
+# =============================================================================
+# Transport tests
+# =============================================================================
+
+
+class TestGoogleDriveTransport:
+    def _mock_service(self, list_files=None, file_content=None):
+        service = MagicMock()
+        files_mock = MagicMock()
+        service.files.return_value = files_mock
+
+        list_result = MagicMock()
+        list_result.execute.return_value = {"files": list_files or []}
+        files_mock.list.return_value = list_result
+
+        if file_content is not None:
+            get_media_result = MagicMock()
+            get_media_result.execute.return_value = file_content.encode("utf-8")
+            files_mock.get_media.return_value = get_media_result
+
+        create_result = MagicMock()
+        create_result.execute.return_value = {"id": "new-file-id"}
+        files_mock.create.return_value = create_result
+
+        update_result = MagicMock()
+        update_result.execute.return_value = {}
+        files_mock.update.return_value = update_result
+
+        return service
+
+    def test_find_file_found(self):
+        service = self._mock_service(list_files=[{"id": "file-123"}])
+        t = GoogleDriveTransport(service, "folder-abc")
+        assert t._find_file("pomodoros.json") == "file-123"
+
+    def test_find_file_not_found(self):
+        service = self._mock_service(list_files=[])
+        t = GoogleDriveTransport(service, "folder-abc")
+        assert t._find_file("pomodoros.json") is None
+
+    def test_find_file_caches_result(self):
+        service = self._mock_service(list_files=[{"id": "file-123"}])
+        t = GoogleDriveTransport(service, "folder-abc")
+        t._find_file("pomodoros.json")
+        t._find_file("pomodoros.json")
+        service.files().list.assert_called_once()
+
+    def test_download_file_returns_content(self):
+        content = '{"pomodoros": [{"id": "1"}]}'
+        service = self._mock_service(list_files=[{"id": "file-123"}], file_content=content)
+        t = GoogleDriveTransport(service, "folder-abc")
+        result = t.download_file("pomodoros.json")
+        assert result == content
+
+    def test_download_file_not_found(self):
+        service = self._mock_service(list_files=[])
+        t = GoogleDriveTransport(service, "folder-abc")
+        assert t.download_file("pomodoros.json") is None
+
+    def test_upload_file_creates_new(self):
+        service = self._mock_service(list_files=[])
+        t = GoogleDriveTransport(service, "folder-abc")
+        t.upload_file("pomodoros.json", '{"pomodoros": []}')
+        service.files().create.assert_called_once()
+
+    def test_upload_file_updates_existing(self):
+        service = self._mock_service(list_files=[{"id": "file-123"}])
+        t = GoogleDriveTransport(service, "folder-abc")
+        t.upload_file("pomodoros.json", '{"pomodoros": []}')
+        service.files().update.assert_called_once()
+
+    def test_file_exists_true(self):
+        service = self._mock_service(list_files=[{"id": "file-123"}])
+        t = GoogleDriveTransport(service, "folder-abc")
+        assert t.file_exists("pomodoros.json") is True
+
+    def test_file_exists_false(self):
+        service = self._mock_service(list_files=[])
+        t = GoogleDriveTransport(service, "folder-abc")
+        assert t.file_exists("pomodoros.json") is False
+
+    def test_ensure_directory_creates_folder(self):
+        service = self._mock_service(list_files=[])
+        t = GoogleDriveTransport(service, None)
+        folder_id = t.ensure_directory()
+        assert folder_id == "new-file-id"
+        service.files().create.assert_called_once()
+
+    def test_ensure_directory_finds_existing(self):
+        service = self._mock_service(list_files=[{"id": "existing-folder"}])
+        t = GoogleDriveTransport(service, None)
+        folder_id = t.ensure_directory()
+        assert folder_id == "existing-folder"
+
+
+# =============================================================================
+# Plugin metadata
+# =============================================================================
+
+
+class TestPluginMetadata:
+    def test_metadata_fields(self):
+        m = storage.PLUGIN_METADATA
+        assert m["id"] == "json-google-drive"
+        assert m["type"] == "storage"
+        assert "folder_id" in m["frontend_fields"]
+        assert m["auth_flow"] == "google_oauth"
+
+    def test_build_context(self):
+        with patch("json_google_drive_storage.build") as mock_build:
+            mock_build.return_value = "drive-service"
+            ctx = storage.build_context("creds", {"folder_id": "folder-123"})
+            assert ctx["service"] == "drive-service"
+            assert ctx["location"] == "folder-123"
+            mock_build.assert_called_once_with("drive", "v3", credentials="creds")
+
+
+# =============================================================================
+# Storage contract — all 11 functions
+# =============================================================================
+
+
+def _mock_transport(file_contents=None):
+    """Create a mock transport that returns given file contents on download."""
+    transport = MagicMock(spec=GoogleDriveTransport)
+    transport.download_file.return_value = file_contents
+    transport.upload_file.return_value = None
+    return transport
+
+
+class TestGetPomodoros:
+    @patch("json_google_drive_storage._transport")
+    def test_returns_pomodoros(self, mock_transport_fn):
+        data = json.dumps({"pomodoros": [
+            {"id": "1", "start_time": "2026-01-15T10:00:00Z"},
+            {"id": "2", "start_time": "2026-01-20T10:00:00Z"},
+        ]})
+        mock_transport_fn.return_value = _mock_transport(data)
+        result = storage.get_pomodoros("svc", "folder", start_date="2026-01-16")
+        assert len(result) == 1
+        assert result[0]["id"] == "2"
+
+    @patch("json_google_drive_storage._transport")
+    def test_empty_file(self, mock_transport_fn):
+        mock_transport_fn.return_value = _mock_transport(None)
+        result = storage.get_pomodoros("svc", "folder")
+        assert result == []
+
+
+class TestSavePomodoro:
+    @patch("json_google_drive_storage._transport")
+    def test_saves_new(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": []}')
+        mock_transport_fn.return_value = t
+        result = storage.save_pomodoro("svc", "folder", {"id": "new", "name": "Test"})
+        assert result is True
+        t.upload_file.assert_called_once()
+
+    @patch("json_google_drive_storage._transport")
+    def test_skips_duplicate(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "existing"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.save_pomodoro("svc", "folder", {"id": "existing", "name": "Dup"})
+        assert result is False
+        t.upload_file.assert_not_called()
+
+
+class TestSavePomodorosBatch:
+    @patch("json_google_drive_storage._transport")
+    def test_batch_save(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}]}')
+        mock_transport_fn.return_value = t
+        count = storage.save_pomodoros_batch("svc", "folder", [{"id": "2"}, {"id": "3"}, {"id": "1"}])
+        assert count == 2
+        t.upload_file.assert_called_once()
+
+    @patch("json_google_drive_storage._transport")
+    def test_batch_empty(self, mock_transport_fn):
+        count = storage.save_pomodoros_batch("svc", "folder", [])
+        assert count == 0
+
+    @patch("json_google_drive_storage._transport")
+    def test_batch_all_duplicates(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}]}')
+        mock_transport_fn.return_value = t
+        count = storage.save_pomodoros_batch("svc", "folder", [{"id": "1"}, {"id": "2"}])
+        assert count == 0
+        t.upload_file.assert_not_called()
+
+
+class TestUpdatePomodoro:
+    @patch("json_google_drive_storage._transport")
+    def test_update_found(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1", "name": "Old"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.update_pomodoro("svc", "folder", "1", {"name": "New"})
+        assert result is True
+        t.upload_file.assert_called_once()
+
+    @patch("json_google_drive_storage._transport")
+    def test_update_not_found(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.update_pomodoro("svc", "folder", "999", {"name": "New"})
+        assert result is False
+        t.upload_file.assert_not_called()
+
+
+class TestDeletePomodoro:
+    @patch("json_google_drive_storage._transport")
+    def test_delete_found(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.delete_pomodoro("svc", "folder", "1")
+        assert result is True
+        t.upload_file.assert_called_once()
+        uploaded = t.upload_file.call_args[0][1]
+        assert '"id": "1"' not in uploaded
+
+    @patch("json_google_drive_storage._transport")
+    def test_delete_not_found(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.delete_pomodoro("svc", "folder", "999")
+        assert result is False
+        t.upload_file.assert_not_called()
+
+
+class TestGetSettings:
+    @patch("json_google_drive_storage._transport")
+    def test_merges_with_defaults(self, mock_transport_fn):
+        t = _mock_transport('{"custom_key": "custom_val"}')
+        mock_transport_fn.return_value = t
+        defaults = {"default_key": "default_val", "custom_key": "overridden"}
+        result = storage.get_settings("svc", "folder", defaults)
+        assert result["default_key"] == "default_val"
+        assert result["custom_key"] == "custom_val"
+
+    @patch("json_google_drive_storage._transport")
+    def test_empty_settings_file(self, mock_transport_fn):
+        t = _mock_transport(None)
+        mock_transport_fn.return_value = t
+        defaults = {"key": "val"}
+        result = storage.get_settings("svc", "folder", defaults)
+        assert result == {"key": "val"}
+
+
+class TestSaveSettings:
+    @patch("json_google_drive_storage._transport")
+    def test_replace_all(self, mock_transport_fn):
+        t = _mock_transport('{"old_key": "old_val"}')
+        mock_transport_fn.return_value = t
+        storage.save_settings("svc", "folder", {"new_key": "new_val"}, replace_all=True)
+        uploaded = json.loads(t.upload_file.call_args[0][1])
+        assert uploaded == {"new_key": "new_val"}
+
+    @patch("json_google_drive_storage._transport")
+    def test_incremental(self, mock_transport_fn):
+        t = _mock_transport('{"existing": 1}')
+        mock_transport_fn.return_value = t
+        storage.save_settings("svc", "folder", {"new": 2}, replace_all=False)
+        uploaded = json.loads(t.upload_file.call_args[0][1])
+        assert uploaded == {"existing": 1, "new": 2}
+
+
+class TestDeduplicatePomodoros:
+    @patch("json_google_drive_storage._transport")
+    def test_removes_dupes(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}, {"id": "1"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.deduplicate_pomodoros("svc", "folder")
+        assert result["removed"] == 1
+        assert result["total"] == 2
+        t.upload_file.assert_called_once()
+
+    @patch("json_google_drive_storage._transport")
+    def test_no_dupes(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.deduplicate_pomodoros("svc", "folder")
+        assert result["removed"] == 0
+        t.upload_file.assert_not_called()
+
+
+class TestCountPomodoros:
+    @patch("json_google_drive_storage._transport")
+    def test_count(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}')
+        mock_transport_fn.return_value = t
+        assert storage.count_pomodoros("svc", "folder") == 3
+
+    @patch("json_google_drive_storage._transport")
+    def test_count_empty(self, mock_transport_fn):
+        t = _mock_transport(None)
+        mock_transport_fn.return_value = t
+        assert storage.count_pomodoros("svc", "folder") == 0
+
+
+class TestClearPomodoros:
+    @patch("json_google_drive_storage._transport")
+    def test_clear(self, mock_transport_fn):
+        t = _mock_transport('{"pomodoros": [{"id": "1"}, {"id": "2"}]}')
+        mock_transport_fn.return_value = t
+        result = storage.clear_pomodoros("svc", "folder")
+        assert result["status"] == "ok"
+        assert result["cleared"] == 2
+        uploaded = json.loads(t.upload_file.call_args[0][1])
+        assert uploaded["pomodoros"] == []

--- a/tests/test_json_storage_core.py
+++ b/tests/test_json_storage_core.py
@@ -1,0 +1,434 @@
+"""Tests for json_storage_core.py — transport-agnostic CRUD, serialization, filtering.
+
+This is core infrastructure. Tests cover every function, edge case, and
+data corruption scenario.
+"""
+
+import json
+
+import json_storage_core as core
+
+
+# =============================================================================
+# parse_pomodoros
+# =============================================================================
+
+
+class TestParsePomodoros:
+    def test_none_returns_empty(self):
+        assert core.parse_pomodoros(None) == []
+
+    def test_empty_string_returns_empty(self):
+        assert core.parse_pomodoros("") == []
+
+    def test_invalid_json_returns_empty(self):
+        assert core.parse_pomodoros("{broken json}") == []
+
+    def test_non_string_non_dict_returns_empty(self):
+        assert core.parse_pomodoros(42) == []
+
+    def test_list_json_string(self):
+        data = json.dumps([{"id": "1"}, {"id": "2"}])
+        result = core.parse_pomodoros(data)
+        assert len(result) == 2
+        assert result[0]["id"] == "1"
+
+    def test_dict_with_pomodoros_key(self):
+        data = json.dumps({"pomodoros": [{"id": "1"}]})
+        result = core.parse_pomodoros(data)
+        assert len(result) == 1
+
+    def test_dict_without_pomodoros_key(self):
+        data = json.dumps({"other": "stuff"})
+        result = core.parse_pomodoros(data)
+        assert result == []
+
+    def test_accepts_dict_directly(self):
+        result = core.parse_pomodoros({"pomodoros": [{"id": "1"}]})
+        assert len(result) == 1
+
+    def test_accepts_list_directly(self):
+        result = core.parse_pomodoros([{"id": "1"}, {"id": "2"}])
+        assert len(result) == 2
+
+    def test_empty_list(self):
+        assert core.parse_pomodoros("[]") == []
+
+    def test_empty_pomodoros_key(self):
+        assert core.parse_pomodoros('{"pomodoros": []}') == []
+
+
+# =============================================================================
+# serialize_pomodoros
+# =============================================================================
+
+
+class TestSerializePomodoros:
+    def test_empty_list(self):
+        result = core.serialize_pomodoros([])
+        parsed = json.loads(result)
+        assert parsed == {"pomodoros": []}
+
+    def test_roundtrip(self):
+        original = [{"id": "1", "name": "Test"}]
+        serialized = core.serialize_pomodoros(original)
+        parsed = core.parse_pomodoros(serialized)
+        assert parsed == original
+
+    def test_preserves_all_fields(self):
+        pomo = {
+            "id": "abc",
+            "name": "Work",
+            "type": "Content",
+            "start_time": "2026-01-15T10:00:00Z",
+            "end_time": "2026-01-15T10:25:00Z",
+            "duration_minutes": 25,
+            "notes": "Some notes",
+        }
+        serialized = core.serialize_pomodoros([pomo])
+        parsed = core.parse_pomodoros(serialized)
+        assert parsed[0] == pomo
+
+
+# =============================================================================
+# parse_settings / serialize_settings
+# =============================================================================
+
+
+class TestSettingsSerialization:
+    def test_parse_none(self):
+        assert core.parse_settings(None) == {}
+
+    def test_parse_empty(self):
+        assert core.parse_settings("") == {}
+
+    def test_parse_invalid_json(self):
+        assert core.parse_settings("{bad}") == {}
+
+    def test_parse_non_dict(self):
+        assert core.parse_settings("[1, 2]") == {}
+
+    def test_parse_valid(self):
+        data = json.dumps({"key": "value", "num": 42})
+        result = core.parse_settings(data)
+        assert result == {"key": "value", "num": 42}
+
+    def test_accepts_dict_directly(self):
+        result = core.parse_settings({"key": "value"})
+        assert result == {"key": "value"}
+
+    def test_roundtrip(self):
+        original = {"timer_preset_1": 5, "sound_enabled": True, "types": ["A", "B"]}
+        serialized = core.serialize_settings(original)
+        parsed = core.parse_settings(serialized)
+        assert parsed == original
+
+
+# =============================================================================
+# add_pomodoro
+# =============================================================================
+
+
+class TestAddPomodoro:
+    def test_add_to_empty_list(self):
+        result, was_new = core.add_pomodoro([], {"id": "1", "name": "Test"})
+        assert was_new is True
+        assert len(result) == 1
+        assert result[0]["id"] == "1"
+
+    def test_add_duplicate_is_skipped(self):
+        existing = [{"id": "1", "name": "Original"}]
+        result, was_new = core.add_pomodoro(existing, {"id": "1", "name": "Duplicate"})
+        assert was_new is False
+        assert len(result) == 1
+        assert result[0]["name"] == "Original"
+
+    def test_add_different_id(self):
+        existing = [{"id": "1"}]
+        result, was_new = core.add_pomodoro(existing, {"id": "2"})
+        assert was_new is True
+        assert len(result) == 2
+
+    def test_mutates_input_list(self):
+        original = [{"id": "1"}]
+        result, _ = core.add_pomodoro(original, {"id": "2"})
+        assert result is original
+
+
+# =============================================================================
+# add_pomodoros_batch
+# =============================================================================
+
+
+class TestAddPomodorosBatch:
+    def test_add_batch_to_empty(self):
+        new = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+        result, added = core.add_pomodoros_batch([], new)
+        assert added == 3
+        assert len(result) == 3
+
+    def test_batch_skips_duplicates(self):
+        existing = [{"id": "1"}, {"id": "2"}]
+        new = [{"id": "2"}, {"id": "3"}, {"id": "1"}]
+        result, added = core.add_pomodoros_batch(existing, new)
+        assert added == 1
+        assert len(result) == 3
+
+    def test_batch_all_duplicates(self):
+        existing = [{"id": "1"}, {"id": "2"}]
+        new = [{"id": "1"}, {"id": "2"}]
+        result, added = core.add_pomodoros_batch(existing, new)
+        assert added == 0
+        assert len(result) == 2
+
+    def test_batch_empty_new(self):
+        existing = [{"id": "1"}]
+        result, added = core.add_pomodoros_batch(existing, [])
+        assert added == 0
+        assert len(result) == 1
+
+    def test_batch_deduplicates_within_new(self):
+        result, added = core.add_pomodoros_batch([], [{"id": "1"}, {"id": "1"}, {"id": "1"}])
+        assert added == 1
+        assert len(result) == 1
+
+
+# =============================================================================
+# update_pomodoro
+# =============================================================================
+
+
+class TestUpdatePomodoro:
+    def test_update_existing(self):
+        pomodoros = [{"id": "1", "name": "Old", "type": "Content"}]
+        result, found = core.update_pomodoro(pomodoros, "1", {"name": "New"})
+        assert found is True
+        assert result[0]["name"] == "New"
+        assert result[0]["type"] == "Content"
+
+    def test_update_nonexistent(self):
+        pomodoros = [{"id": "1", "name": "Test"}]
+        result, found = core.update_pomodoro(pomodoros, "999", {"name": "New"})
+        assert found is False
+        assert result[0]["name"] == "Test"
+
+    def test_update_multiple_fields(self):
+        pomodoros = [{"id": "1", "name": "Old", "type": "A", "notes": "old note"}]
+        result, found = core.update_pomodoro(pomodoros, "1", {"name": "New", "type": "B", "notes": "new note"})
+        assert found is True
+        assert result[0]["name"] == "New"
+        assert result[0]["type"] == "B"
+        assert result[0]["notes"] == "new note"
+
+    def test_update_empty_list(self):
+        result, found = core.update_pomodoro([], "1", {"name": "New"})
+        assert found is False
+        assert result == []
+
+
+# =============================================================================
+# delete_pomodoro
+# =============================================================================
+
+
+class TestDeletePomodoro:
+    def test_delete_existing(self):
+        pomodoros = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+        result, found = core.delete_pomodoro(pomodoros, "2")
+        assert found is True
+        assert len(result) == 2
+        assert all(p["id"] != "2" for p in result)
+
+    def test_delete_nonexistent(self):
+        pomodoros = [{"id": "1"}]
+        result, found = core.delete_pomodoro(pomodoros, "999")
+        assert found is False
+        assert len(result) == 1
+
+    def test_delete_from_empty(self):
+        result, found = core.delete_pomodoro([], "1")
+        assert found is False
+        assert result == []
+
+    def test_delete_only_item(self):
+        result, found = core.delete_pomodoro([{"id": "1"}], "1")
+        assert found is True
+        assert result == []
+
+    def test_delete_returns_new_list(self):
+        original = [{"id": "1"}, {"id": "2"}]
+        result, _ = core.delete_pomodoro(original, "1")
+        assert result is not original
+
+
+# =============================================================================
+# filter_by_date
+# =============================================================================
+
+
+class TestFilterByDate:
+    def _make_pomodoros(self):
+        return [
+            {"id": "1", "start_time": "2026-01-10T10:00:00Z"},
+            {"id": "2", "start_time": "2026-01-15T10:00:00Z"},
+            {"id": "3", "start_time": "2026-01-20T10:00:00Z"},
+            {"id": "4", "start_time": "2026-01-25T10:00:00Z"},
+        ]
+
+    def test_no_filter(self):
+        result = core.filter_by_date(self._make_pomodoros())
+        assert len(result) == 4
+
+    def test_start_date_only(self):
+        result = core.filter_by_date(self._make_pomodoros(), start_date="2026-01-15")
+        assert len(result) == 3
+        assert all(p["start_time"] >= "2026-01-15" for p in result)
+
+    def test_end_date_only(self):
+        result = core.filter_by_date(self._make_pomodoros(), end_date="2026-01-20T23:59:59Z")
+        assert len(result) == 3
+
+    def test_both_dates(self):
+        result = core.filter_by_date(self._make_pomodoros(), start_date="2026-01-14", end_date="2026-01-21")
+        assert len(result) == 2
+
+    def test_sorted_descending(self):
+        result = core.filter_by_date(self._make_pomodoros())
+        times = [p["start_time"] for p in result]
+        assert times == sorted(times, reverse=True)
+
+    def test_empty_list(self):
+        assert core.filter_by_date([], start_date="2026-01-01") == []
+
+    def test_no_matches(self):
+        result = core.filter_by_date(self._make_pomodoros(), start_date="2027-01-01")
+        assert result == []
+
+    def test_missing_start_time_field(self):
+        pomodoros = [{"id": "1"}, {"id": "2", "start_time": "2026-01-15T10:00:00Z"}]
+        result = core.filter_by_date(pomodoros, start_date="2026-01-10")
+        assert len(result) == 1
+
+
+# =============================================================================
+# deduplicate
+# =============================================================================
+
+
+class TestDeduplicate:
+    def test_no_duplicates(self):
+        pomodoros = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
+        result, removed = core.deduplicate(pomodoros)
+        assert removed == 0
+        assert len(result) == 3
+
+    def test_removes_duplicates(self):
+        pomodoros = [{"id": "1"}, {"id": "2"}, {"id": "1"}, {"id": "3"}, {"id": "2"}]
+        result, removed = core.deduplicate(pomodoros)
+        assert removed == 2
+        assert len(result) == 3
+
+    def test_keeps_first_occurrence(self):
+        pomodoros = [
+            {"id": "1", "name": "First"},
+            {"id": "1", "name": "Second"},
+        ]
+        result, removed = core.deduplicate(pomodoros)
+        assert removed == 1
+        assert result[0]["name"] == "First"
+
+    def test_empty_list(self):
+        result, removed = core.deduplicate([])
+        assert removed == 0
+        assert result == []
+
+    def test_single_item(self):
+        result, removed = core.deduplicate([{"id": "1"}])
+        assert removed == 0
+        assert len(result) == 1
+
+    def test_all_duplicates(self):
+        pomodoros = [{"id": "1"}, {"id": "1"}, {"id": "1"}]
+        result, removed = core.deduplicate(pomodoros)
+        assert removed == 2
+        assert len(result) == 1
+
+
+# =============================================================================
+# merge_settings
+# =============================================================================
+
+
+class TestMergeSettings:
+    def test_replace_all(self):
+        existing = {"a": 1, "b": 2, "c": 3}
+        updates = {"x": 10, "y": 20}
+        result = core.merge_settings(existing, updates, replace_all=True)
+        assert result == {"x": 10, "y": 20}
+
+    def test_incremental_update(self):
+        existing = {"a": 1, "b": 2}
+        updates = {"b": 99, "c": 3}
+        result = core.merge_settings(existing, updates, replace_all=False)
+        assert result == {"a": 1, "b": 99, "c": 3}
+
+    def test_incremental_preserves_existing(self):
+        existing = {"a": 1, "b": 2}
+        result = core.merge_settings(existing, {}, replace_all=False)
+        assert result == {"a": 1, "b": 2}
+
+    def test_returns_new_dict(self):
+        existing = {"a": 1}
+        result = core.merge_settings(existing, {"b": 2})
+        assert result is not existing
+
+
+# =============================================================================
+# Full roundtrip: serialize → parse → CRUD → serialize
+# =============================================================================
+
+
+class TestFullRoundtrip:
+    def test_lifecycle(self):
+        pomodoros = []
+
+        pomodoros, _ = core.add_pomodoro(pomodoros, {
+            "id": "p1", "name": "Task 1", "type": "Content",
+            "start_time": "2026-01-15T10:00:00Z", "end_time": "2026-01-15T10:25:00Z",
+            "duration_minutes": 25, "notes": None,
+        })
+        pomodoros, _ = core.add_pomodoro(pomodoros, {
+            "id": "p2", "name": "Task 2", "type": "Product",
+            "start_time": "2026-01-15T11:00:00Z", "end_time": "2026-01-15T11:25:00Z",
+            "duration_minutes": 25, "notes": "Important",
+        })
+
+        serialized = core.serialize_pomodoros(pomodoros)
+        restored = core.parse_pomodoros(serialized)
+        assert len(restored) == 2
+
+        restored, found = core.update_pomodoro(restored, "p1", {"name": "Updated Task"})
+        assert found is True
+        assert restored[0]["name"] == "Updated Task"
+
+        restored, found = core.delete_pomodoro(restored, "p2")
+        assert found is True
+        assert len(restored) == 1
+
+        final = core.serialize_pomodoros(restored)
+        final_parsed = core.parse_pomodoros(final)
+        assert len(final_parsed) == 1
+        assert final_parsed[0]["name"] == "Updated Task"
+
+    def test_large_batch(self):
+        pomodoros = [{"id": str(i), "name": f"Task {i}", "start_time": f"2026-01-{15 + (i % 15):02d}T10:00:00Z"} for i in range(1000)]
+        serialized = core.serialize_pomodoros(pomodoros)
+        restored = core.parse_pomodoros(serialized)
+        assert len(restored) == 1000
+
+        filtered = core.filter_by_date(restored, start_date="2026-01-20", end_date="2026-01-25")
+        assert all("2026-01-20" <= p["start_time"] <= "2026-01-25" for p in filtered)
+
+        deduped, removed = core.deduplicate(restored)
+        assert removed == 0
+        assert len(deduped) == 1000

--- a/tests/test_json_storage_core.py
+++ b/tests/test_json_storage_core.py
@@ -8,7 +8,6 @@ import json
 
 import json_storage_core as core
 
-
 # =============================================================================
 # parse_pomodoros
 # =============================================================================
@@ -392,16 +391,30 @@ class TestFullRoundtrip:
     def test_lifecycle(self):
         pomodoros = []
 
-        pomodoros, _ = core.add_pomodoro(pomodoros, {
-            "id": "p1", "name": "Task 1", "type": "Content",
-            "start_time": "2026-01-15T10:00:00Z", "end_time": "2026-01-15T10:25:00Z",
-            "duration_minutes": 25, "notes": None,
-        })
-        pomodoros, _ = core.add_pomodoro(pomodoros, {
-            "id": "p2", "name": "Task 2", "type": "Product",
-            "start_time": "2026-01-15T11:00:00Z", "end_time": "2026-01-15T11:25:00Z",
-            "duration_minutes": 25, "notes": "Important",
-        })
+        pomodoros, _ = core.add_pomodoro(
+            pomodoros,
+            {
+                "id": "p1",
+                "name": "Task 1",
+                "type": "Content",
+                "start_time": "2026-01-15T10:00:00Z",
+                "end_time": "2026-01-15T10:25:00Z",
+                "duration_minutes": 25,
+                "notes": None,
+            },
+        )
+        pomodoros, _ = core.add_pomodoro(
+            pomodoros,
+            {
+                "id": "p2",
+                "name": "Task 2",
+                "type": "Product",
+                "start_time": "2026-01-15T11:00:00Z",
+                "end_time": "2026-01-15T11:25:00Z",
+                "duration_minutes": 25,
+                "notes": "Important",
+            },
+        )
 
         serialized = core.serialize_pomodoros(pomodoros)
         restored = core.parse_pomodoros(serialized)
@@ -421,7 +434,10 @@ class TestFullRoundtrip:
         assert final_parsed[0]["name"] == "Updated Task"
 
     def test_large_batch(self):
-        pomodoros = [{"id": str(i), "name": f"Task {i}", "start_time": f"2026-01-{15 + (i % 15):02d}T10:00:00Z"} for i in range(1000)]
+        pomodoros = [
+            {"id": str(i), "name": f"Task {i}", "start_time": f"2026-01-{15 + (i % 15):02d}T10:00:00Z"}
+            for i in range(1000)
+        ]
         serialized = core.serialize_pomodoros(pomodoros)
         restored = core.parse_pomodoros(serialized)
         assert len(restored) == 1000

--- a/transports/google_drive_transport.py
+++ b/transports/google_drive_transport.py
@@ -5,7 +5,6 @@ import io
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
 
-
 ACQUACOTTA_FOLDER_NAME = "Acquacotta"
 
 

--- a/transports/google_drive_transport.py
+++ b/transports/google_drive_transport.py
@@ -1,0 +1,97 @@
+"""Google Drive transport — thin adapter for JSON file operations on Drive."""
+
+import io
+
+from googleapiclient.http import MediaIoBaseUpload
+
+
+ACQUACOTTA_FOLDER_NAME = "Acquacotta"
+
+
+class GoogleDriveTransport:
+    def __init__(self, drive_service, folder_id):
+        self._service = drive_service
+        self._folder_id = folder_id
+
+    def _find_file(self, filename):
+        """Find a file by name in the Acquacotta folder. Returns file ID or None."""
+        resp = self._service.files().list(
+            q=f"name='{filename}' and '{self._folder_id}' in parents and trashed=false",
+            fields="files(id)",
+            spaces="drive",
+        ).execute()
+        files = resp.get("files", [])
+        return files[0]["id"] if files else None
+
+    def download_file(self, filename):
+        """Download a file's content as a string. Returns None if not found."""
+        file_id = self._find_file(filename)
+        if not file_id:
+            return None
+        content = self._service.files().get_media(fileId=file_id).execute()
+        if isinstance(content, bytes):
+            return content.decode("utf-8")
+        return str(content)
+
+    def upload_file(self, filename, content):
+        """Upload/overwrite a file in the Acquacotta folder."""
+        media = MediaIoBaseUpload(
+            io.BytesIO(content.encode("utf-8")),
+            mimetype="application/json",
+            resumable=False,
+        )
+        file_id = self._find_file(filename)
+        if file_id:
+            self._service.files().update(
+                fileId=file_id,
+                media_body=media,
+            ).execute()
+        else:
+            self._service.files().create(
+                body={
+                    "name": filename,
+                    "parents": [self._folder_id],
+                    "mimeType": "application/json",
+                },
+                media_body=media,
+                fields="id",
+            ).execute()
+
+    def ensure_directory(self):
+        """Ensure the Acquacotta folder exists. Returns folder_id.
+
+        If self._folder_id is already set and valid, returns it.
+        Otherwise searches for or creates the folder.
+        """
+        if self._folder_id:
+            try:
+                self._service.files().get(
+                    fileId=self._folder_id, fields="id,trashed"
+                ).execute()
+                return self._folder_id
+            except Exception:
+                pass
+
+        resp = self._service.files().list(
+            q=f"name='{ACQUACOTTA_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false",
+            fields="files(id)",
+            spaces="drive",
+        ).execute()
+        folders = resp.get("files", [])
+        if folders:
+            self._folder_id = folders[0]["id"]
+            return self._folder_id
+
+        folder = self._service.files().create(
+            body={
+                "name": ACQUACOTTA_FOLDER_NAME,
+                "mimeType": "application/vnd.google-apps.folder",
+            },
+            fields="id",
+        ).execute()
+        self._folder_id = folder["id"]
+        return self._folder_id
+
+    def file_exists(self, filename):
+        """Check if a file exists in the folder."""
+        return self._find_file(filename) is not None

--- a/transports/google_drive_transport.py
+++ b/transports/google_drive_transport.py
@@ -2,6 +2,7 @@
 
 import io
 
+from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
 
 
@@ -69,7 +70,7 @@ class GoogleDriveTransport:
                     fileId=self._folder_id, fields="id,trashed"
                 ).execute()
                 return self._folder_id
-            except Exception:
+            except HttpError:
                 pass
 
         resp = self._service.files().list(

--- a/transports/google_drive_transport.py
+++ b/transports/google_drive_transport.py
@@ -15,11 +15,15 @@ class GoogleDriveTransport:
 
     def _find_file(self, filename):
         """Find a file by name in the Acquacotta folder. Returns file ID or None."""
-        resp = self._service.files().list(
-            q=f"name='{filename}' and '{self._folder_id}' in parents and trashed=false",
-            fields="files(id)",
-            spaces="drive",
-        ).execute()
+        resp = (
+            self._service.files()
+            .list(
+                q=f"name='{filename}' and '{self._folder_id}' in parents and trashed=false",
+                fields="files(id)",
+                spaces="drive",
+            )
+            .execute()
+        )
         files = resp.get("files", [])
         return files[0]["id"] if files else None
 
@@ -65,30 +69,36 @@ class GoogleDriveTransport:
         """
         if self._folder_id:
             try:
-                self._service.files().get(
-                    fileId=self._folder_id, fields="id,trashed"
-                ).execute()
+                self._service.files().get(fileId=self._folder_id, fields="id,trashed").execute()
                 return self._folder_id
             except HttpError:
                 pass
 
-        resp = self._service.files().list(
-            q=f"name='{ACQUACOTTA_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false",
-            fields="files(id)",
-            spaces="drive",
-        ).execute()
+        resp = (
+            self._service.files()
+            .list(
+                q=f"name='{ACQUACOTTA_FOLDER_NAME}' and mimeType='application/vnd.google-apps.folder' and trashed=false",
+                fields="files(id)",
+                spaces="drive",
+            )
+            .execute()
+        )
         folders = resp.get("files", [])
         if folders:
             self._folder_id = folders[0]["id"]
             return self._folder_id
 
-        folder = self._service.files().create(
-            body={
-                "name": ACQUACOTTA_FOLDER_NAME,
-                "mimeType": "application/vnd.google-apps.folder",
-            },
-            fields="id",
-        ).execute()
+        folder = (
+            self._service.files()
+            .create(
+                body={
+                    "name": ACQUACOTTA_FOLDER_NAME,
+                    "mimeType": "application/vnd.google-apps.folder",
+                },
+                fields="id",
+            )
+            .execute()
+        )
         self._folder_id = folder["id"]
         return self._folder_id
 

--- a/transports/google_drive_transport.py
+++ b/transports/google_drive_transport.py
@@ -12,9 +12,13 @@ class GoogleDriveTransport:
     def __init__(self, drive_service, folder_id):
         self._service = drive_service
         self._folder_id = folder_id
+        self._file_id_cache = {}
 
     def _find_file(self, filename):
         """Find a file by name in the Acquacotta folder. Returns file ID or None."""
+        cached = self._file_id_cache.get(filename)
+        if cached:
+            return cached
         resp = (
             self._service.files()
             .list(
@@ -25,7 +29,10 @@ class GoogleDriveTransport:
             .execute()
         )
         files = resp.get("files", [])
-        return files[0]["id"] if files else None
+        if files:
+            self._file_id_cache[filename] = files[0]["id"]
+            return files[0]["id"]
+        return None
 
     def download_file(self, filename):
         """Download a file's content as a string. Returns None if not found."""


### PR DESCRIPTION
## Summary

- **json_storage_core.py** — Transport-agnostic serialization, CRUD, filtering, dedup (pure functions on Python dicts/lists)
- **transports/google_drive_transport.py** — 4-function Drive API adapter: download_file, upload_file, ensure_directory, file_exists
- **json_google_drive_storage.py** — Full 11-function storage plugin contract wiring core + transport
- **app.py** — Plugin-aware `_storage_context()`, `is_logged_in()`, and OAuth callback with generic IndexedDB hydration
- **storage.js** — Generic credential payload (sends all location fields; each plugin uses what it needs)
- **storage_api.py** — `StorageUnavailable` no longer inherits from `HttpError`
- **Containerfile** — Updated with new source files

New users default to `json-google-drive`. Existing Sheets users continue working via the `sheets` plugin. Legacy `user_spreadsheets.json` auto-migrates to `user_storage.json`.

Closes #83

## Test plan
- [ ] Fresh login creates `Acquacotta/` folder on Drive with `pomodoros.json` and `settings.json`
- [ ] CRUD operations (create, read, update, delete pomodoro) work through JSON backend
- [ ] Settings persist across sessions via `settings.json`
- [ ] Deduplication works on `pomodoros.json`
- [ ] Switch to Sheets plugin still works (toggle via `/api/plugins/toggle`)
- [ ] Existing user with `spreadsheet_id` in IndexedDB can still use Sheets backend
- [ ] No new OAuth permissions required (drive.file covers both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)