### PR TITLE
feat: Todos plugin with cascading Type dropdown (#86)

### DIFF
--- a/.specify/specs/003-todos-plugin/plan.md
+++ b/.specify/specs/003-todos-plugin/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan: Todos Plugin
+
+**Branch**: `feature/86-todos-plugin` | **Date**: 2026-06-21 | **Spec**: `specs/003-todos-plugin/spec.md`
+**Input**: Feature specification from `/specs/003-todos-plugin/spec.md`
+
+## Summary
+
+Add a Todos plugin as the first `extension`-type plugin in Acquacotta. Introduces a "To-do" tab in the dashboard with full CRUD, custom lists, priority/due-date sorting, and the ability to link pomodoro sessions to todos. Data is stored in IndexedDB (offline-first) and synced to `plugins/todos/data.json` on Google Drive.
+
+## Technical Context
+
+**Language/Version**: Python 3.x (Flask backend), vanilla JavaScript ES6+ (frontend)
+**Primary Dependencies**: Flask, Google Drive API (existing), IndexedDB (existing)
+**Storage**: IndexedDB (local, offline-first) + Google Drive JSON file (`plugins/todos/data.json`)
+**Testing**: Manual verification + existing test patterns
+**Target Platform**: Web browser (desktop + mobile responsive)
+**Project Type**: Web application (monolith — single `index.html`, single `app.py`)
+**Performance Goals**: <100ms for local operations, <5s for Drive sync
+**Constraints**: No frameworks (vanilla JS per constitution), offline-first, no persistent server state
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Privacy by Design | PASS | No new OAuth scopes needed — `drive.file` already covers app-created files |
+| II. User Data Ownership | PASS | Data lives in user's Drive as JSON, portable, deletable |
+| III. Simplicity & Focus | PASS | Todos directly support daily personal productivity |
+| IV. Timer Agnosticism | PASS | Linking is optional — manual entry and external timers unaffected |
+| V. Offline-First | PASS | IndexedDB is primary store, Drive sync is background |
+| VI. Container-Ready | PASS | No new server state, no new volumes |
+
+## Architecture
+
+### Data Flow
+
+```
+Browser (IndexedDB)          Flask Backend              Google Drive
+┌─────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│ todos_store      │────▶│ /api/todos/*     │────▶│ plugins/todos/   │
+│ (offline-first)  │◀────│ (proxy to Drive) │◀────│   data.json      │
+└─────────────────┘     └──────────────────┘     └──────────────────┘
+```
+
+### Plugin Registration
+
+Register as `extension` type (non-singleton) in `plugin_registry.py`. The Todos plugin uses the existing JSON-on-Drive transport for its data file — same pattern as pomodoros.json but in the `plugins/todos/` subfolder.
+
+### Data Model
+
+```json
+{
+  "lists": [
+    { "id": "uuid", "name": "Professional", "order": 0 },
+    { "id": "uuid", "name": "Personal", "order": 1 }
+  ],
+  "todos": [
+    {
+      "id": "uuid",
+      "title": "Review RHEL 10 roadmap",
+      "notes": "Focus on container improvements",
+      "status": "pending",
+      "priority": "high",
+      "due_date": "2026-06-25",
+      "list_id": "uuid",
+      "created_at": "2026-06-21T10:00:00Z",
+      "completed_at": null,
+      "linked_pomodoros": []
+    }
+  ]
+}
+```
+
+### Pomodoro Data Model Extension
+
+Add `linked_todo_id` (nullable string) to pomodoro records. This field is ignored by existing code, backward-compatible. The same pattern will be reused for `linked_ticket_id` when the ticket system plugin (#88) lands.
+
+```javascript
+// Extended pomodoro object
+{
+  id: "uuid",
+  name: "RHEL 10 review",
+  type: "Product",
+  duration_minutes: 25,
+  notes: "...",
+  linked_todo_id: "todo-uuid-here"  // NEW — nullable
+}
+```
+
+## Project Structure
+
+### Source Code Changes
+
+```
+app.py                          # Add /api/todos/* routes
+todos_plugin.py                 # NEW — plugin module with Drive read/write
+plugin_registry.py              # Register todos as extension plugin
+templates/index.html            # Add To-do tab, todo UI, timer linking dropdown
+```
+
+### No New Files for Storage
+
+Todos reuses the existing `json_storage_core.py` + `google_drive_transport.py` for reading/writing `plugins/todos/data.json`. No new transport or storage module needed.
+
+## Implementation Phases
+
+### Phase 1: Frontend — To-do Tab + IndexedDB (P1 stories)
+
+1. Add "To-do" tab button to nav bar (between History and Settings)
+2. Add `todos-view` tabpanel with:
+   - List selector/grouping
+   - Todo list with checkbox, title, priority badge, due date
+   - Add/edit todo form (inline or modal)
+   - Completed section (collapsible)
+3. IndexedDB `todos` object store for offline-first CRUD
+4. List management UI (create, rename, reorder, delete)
+5. Sorting: overdue first → priority desc → created_at asc
+
+### Phase 2: Backend — Drive Sync + API Routes (P2 stories)
+
+1. `todos_plugin.py` — read/write `plugins/todos/data.json` via Drive transport
+2. Flask routes:
+   - `GET /api/todos` — fetch all todos and lists
+   - `POST /api/todos` — create todo
+   - `PUT /api/todos/<id>` — update todo
+   - `DELETE /api/todos/<id>` — delete todo
+   - `GET /api/todos/lists` — fetch lists
+   - `POST /api/todos/lists` — create list
+   - `PUT /api/todos/lists/<id>` — update list
+   - `DELETE /api/todos/lists/<id>` — delete list
+   - `POST /api/todos/sync` — full sync (push local to Drive)
+   - `GET /api/todos/sync` — pull from Drive
+3. Register as `extension` plugin in plugin_registry
+4. Sync logic: same pattern as pomodoro sync (IndexedDB → batch push to Drive)
+
+### Phase 3: Pomodoro Linking (P2 story)
+
+1. Add `linked_todo_id` field to pomodoro creation/edit forms
+2. "Linked to" dropdown on timer view — populated from active (non-completed) todos
+3. Display linked todo title in History tab entries
+4. Calculate and display total time on each todo in the To-do tab
+5. Handle orphaned links gracefully (deleted todos)
+
+### Phase 4: Google Tasks Import (P3 story — stretch)
+
+1. Settings section: "Import from Google Tasks" button
+2. Requires `tasks.readonly` OAuth scope (additional consent prompt)
+3. Maps Google Tasks lists → Acquacotta lists, tasks → todos
+4. Deduplication by title + list name
+5. Subtask flattening with parent reference in notes
+
+## Complexity Tracking
+
+No constitution violations. The feature fits cleanly within the existing architecture — it's the designed use case for the `extension` plugin type.

--- a/.specify/specs/003-todos-plugin/plan.md
+++ b/.specify/specs/003-todos-plugin/plan.md
@@ -135,8 +135,8 @@ Todos reuses the existing `json_storage_core.py` + `google_drive_transport.py` f
 ### Phase 3: Pomodoro Linking (P2 story)
 
 1. Add `linked_todo_id` field to pomodoro creation/edit forms
-2. "Linked to" dropdown on timer view — populated from active (non-completed) todos
-3. Display linked todo title in History tab entries
+2. Two-level "Linked to" picker on timer view: list selector → todo selector within that list (only active todos)
+3. Display linked todo in History tab entries as "List > Todo title"
 4. Calculate and display total time on each todo in the To-do tab
 5. Handle orphaned links gracefully (deleted todos)
 

--- a/.specify/specs/003-todos-plugin/spec.md
+++ b/.specify/specs/003-todos-plugin/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Todos Plugin
+
+**Feature Branch**: `feature/86-todos-plugin`
+**Created**: 2026-06-21
+**Status**: Draft
+**Input**: GitHub Issue #86 + Google Tasks feature analysis + user requirements
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View and manage todos in a dashboard tab (Priority: P1)
+
+As a user, I want a "To-do" tab in the Acquacotta dashboard where I can see all my todos organized by custom lists, so I can manage tasks alongside my time tracking without switching to Google Tasks.
+
+**Why this priority**: The tab is the foundation — without it, no other todo functionality has a home. This delivers immediate value by consolidating the scatter of Google Tasks into the daily cockpit.
+
+**Independent Test**: Navigate to the To-do tab, create a todo, edit it, mark it complete, delete it. All CRUD operations work with data persisted in IndexedDB (offline) and synced to Drive (online).
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the dashboard, **When** they click the "To-do" tab, **Then** the todo view shows with their todos grouped by list
+2. **Given** the user is on the To-do tab, **When** they click "Add Todo", **Then** a form appears with fields: title, notes, list (dropdown), priority, due date
+3. **Given** a todo exists, **When** the user clicks the checkbox, **Then** the todo is marked complete with a timestamp and moves to a "Completed" section
+4. **Given** a todo exists, **When** the user clicks edit, **Then** they can modify title, notes, list, priority, and due date
+5. **Given** a completed todo, **When** the user clicks delete, **Then** the todo is permanently removed
+6. **Given** todos exist with different priorities, **When** viewing a list, **Then** todos sort by: overdue first, then by priority (high > medium > low), then by creation date
+
+---
+
+### User Story 2 - Custom lists (Priority: P1)
+
+As a user, I want to create, rename, and delete custom lists to organize my todos by context (Professional, Personal, Shopping, Travel, etc.), mirroring the organizational structure I already use in Google Tasks.
+
+**Why this priority**: Custom lists are core to the organizing model. Without them, the todo plugin is a flat list — unusable for someone with 6+ lists like Scott.
+
+**Independent Test**: Create a new list, rename it, move a todo to it, delete an empty list.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the To-do tab, **When** they click "Manage Lists", **Then** they can create a new list with a custom name
+2. **Given** multiple lists exist, **When** viewing the To-do tab, **Then** todos are grouped under list headings with collapsible sections
+3. **Given** a list exists with no todos, **When** the user deletes it, **Then** the list is removed
+4. **Given** a list has todos, **When** the user tries to delete it, **Then** a confirmation asks whether to move todos to another list or delete them
+5. **Given** lists exist, **When** the user drags a list heading, **Then** they can reorder lists
+
+---
+
+### User Story 3 - Link pomodoro to a todo (Priority: P2)
+
+As a user, when I start or log a pomodoro, I want to optionally select a todo I'm working on, so my time tracking connects to my task list and I can later see how much time I spent on each todo.
+
+**Why this priority**: This is the key differentiator over Google Tasks — linking time to tasks. Deferred to P2 because CRUD (P1) must work first. This also lays infrastructure for ticket linking (#88 RT integration) later.
+
+**Independent Test**: Start a pomodoro, select a todo from the dropdown, complete it. The pomodoro record shows the linked todo. The todo shows total time spent.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on the Timer tab starting/logging a pomodoro, **When** the timer form loads, **Then** an optional "Linked to" dropdown shows active todos from all lists
+2. **Given** a pomodoro is linked to a todo, **When** viewing the todo detail, **Then** the total time spent (sum of linked pomodoro durations) is displayed
+3. **Given** a pomodoro is linked to a todo, **When** viewing the History tab, **Then** the linked todo title appears on the pomodoro entry
+4. **Given** a todo has linked pomodoros, **When** the todo is deleted, **Then** the pomodoros remain but their link is cleared (orphan-safe)
+
+---
+
+### User Story 4 - Todo persistence on Drive (Priority: P2)
+
+As a user, I want my todos stored in `plugins/todos/data.json` on Google Drive alongside my pomodoro data, so my todos sync across devices and I own my data.
+
+**Why this priority**: Without cloud persistence, todos only live in IndexedDB and are lost on browser clear. But local-first (P1 CRUD in IndexedDB) must work before sync is layered on.
+
+**Independent Test**: Create a todo while logged in, verify it appears in `Acquacotta/plugins/todos/data.json` on Drive. Clear IndexedDB, reload — todos rehydrate from Drive.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is logged in with Google, **When** they create/edit/complete/delete a todo, **Then** the change syncs to `plugins/todos/data.json` on Drive
+2. **Given** the user clears their browser data, **When** they log back in, **Then** todos rehydrate from Drive
+3. **Given** the user is offline, **When** they modify todos, **Then** changes queue in IndexedDB and sync when connectivity returns
+
+---
+
+### User Story 5 - Google Tasks import (Priority: P3)
+
+As a user, I want to import my existing Google Tasks into Acquacotta's Todos plugin as a one-time migration, so I can consolidate without re-entering hundreds of tasks.
+
+**Why this priority**: Nice-to-have for migration. Users can start fresh or manually recreate their active todos. The import is a convenience, not a blocker.
+
+**Independent Test**: Click "Import from Google Tasks" in settings, authorize the Tasks API scope, verify all lists and tasks appear in the Todos tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user clicks "Import from Google Tasks", **When** authorization succeeds, **Then** all Google Tasks lists and their tasks are imported with titles, notes, due dates, and completion status preserved
+2. **Given** an import has already been run, **When** the user runs it again, **Then** duplicates are detected by title+list and skipped
+3. **Given** Google Tasks has subtasks, **When** imported, **Then** subtasks become top-level todos with a note indicating the parent (flatten, don't support hierarchy)
+
+---
+
+### Edge Cases
+
+- What happens when a linked todo is deleted? Pomodoros keep their `linked_todo_id` but display "(deleted todo)" instead of the title.
+- What happens when the user has no lists? A default "General" list is auto-created on first use.
+- What happens with very long todo titles? Truncate with ellipsis in the list view, show full title in detail/edit view.
+- What happens when Drive sync fails mid-write? Local IndexedDB is source of truth; retry on next sync cycle.
+- Maximum todos per list? No enforced limit — JSON file stays small even at thousands of entries.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST add a "To-do" tab to the main navigation between History and Settings
+- **FR-002**: System MUST support CRUD operations on todos: create, read, update, delete
+- **FR-003**: System MUST support custom lists: create, rename, reorder, delete
+- **FR-004**: Each todo MUST have: id, title, notes, status (pending/completed), priority (high/medium/low/none), due_date, list, created_at, completed_at, linked_pomodoros[]
+- **FR-005**: System MUST persist todos in IndexedDB for offline-first operation
+- **FR-006**: System MUST sync todos to `plugins/todos/data.json` on Google Drive when logged in
+- **FR-007**: System MUST add an optional "Linked to" dropdown on the timer/manual-entry forms showing active todos
+- **FR-008**: Pomodoro data model MUST support a `linked_todo_id` field (nullable, string)
+- **FR-009**: System MUST display total time spent (from linked pomodoros) on each todo
+- **FR-010**: System MUST register as an `extension` plugin type in the plugin registry
+- **FR-011**: System MUST sort todos: overdue first, then by priority descending, then by creation date
+- **FR-012**: Completed todos MUST show in a collapsible "Completed" section at the bottom of each list
+
+### Key Entities
+
+- **Todo**: The core entity — a task with title, notes, priority, due date, list membership, completion status, and linked pomodoros
+- **TodoList**: A named grouping of todos (e.g., "Professional", "Personal", "Shopping"). User-customizable.
+- **Pomodoro (existing, extended)**: Extended with nullable `linked_todo_id` field to connect time to tasks
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can create, edit, complete, and delete todos entirely offline (IndexedDB only)
+- **SC-002**: Todo CRUD operations respond in under 100ms (constitution performance target)
+- **SC-003**: Syncing up to 500 todos to Drive completes within 5 seconds
+- **SC-004**: Linking a pomodoro to a todo adds no perceptible latency to the timer save flow
+- **SC-005**: The Todos tab renders correctly on mobile viewports (min 320px width)

--- a/.specify/specs/003-todos-plugin/spec.md
+++ b/.specify/specs/003-todos-plugin/spec.md
@@ -54,10 +54,11 @@ As a user, when I start or log a pomodoro, I want to optionally select a todo I'
 
 **Acceptance Scenarios**:
 
-1. **Given** the user is on the Timer tab starting/logging a pomodoro, **When** the timer form loads, **Then** an optional "Linked to" dropdown shows active todos from all lists
-2. **Given** a pomodoro is linked to a todo, **When** viewing the todo detail, **Then** the total time spent (sum of linked pomodoro durations) is displayed
-3. **Given** a pomodoro is linked to a todo, **When** viewing the History tab, **Then** the linked todo title appears on the pomodoro entry
-4. **Given** a todo has linked pomodoros, **When** the todo is deleted, **Then** the pomodoros remain but their link is cleared (orphan-safe)
+1. **Given** the user is on the Timer tab starting/logging a pomodoro, **When** they click the optional "Linked to" selector, **Then** a two-level picker appears: first select a list (Professional, Personal, etc.), then select a todo within that list
+2. **Given** the user has selected a list in the picker, **When** the todos load, **Then** only active (non-completed) todos from that list are shown, sorted by priority
+3. **Given** a pomodoro is linked to a todo, **When** viewing the todo detail, **Then** the total time spent (sum of linked pomodoro durations) is displayed
+4. **Given** a pomodoro is linked to a todo, **When** viewing the History tab, **Then** the linked todo title appears on the pomodoro entry (format: "List > Todo title")
+5. **Given** a todo has linked pomodoros, **When** the todo is deleted, **Then** the pomodoros remain but their link is cleared (orphan-safe)
 
 ---
 
@@ -111,7 +112,7 @@ As a user, I want to import my existing Google Tasks into Acquacotta's Todos plu
 - **FR-004**: Each todo MUST have: id, title, notes, status (pending/completed), priority (high/medium/low/none), due_date, list, created_at, completed_at, linked_pomodoros[]
 - **FR-005**: System MUST persist todos in IndexedDB for offline-first operation
 - **FR-006**: System MUST sync todos to `plugins/todos/data.json` on Google Drive when logged in
-- **FR-007**: System MUST add an optional "Linked to" dropdown on the timer/manual-entry forms showing active todos
+- **FR-007**: System MUST add an optional "Linked to" two-level picker on the timer/manual-entry forms: first select a list, then select a todo within that list
 - **FR-008**: Pomodoro data model MUST support a `linked_todo_id` field (nullable, string)
 - **FR-009**: System MUST display total time spent (from linked pomodoros) on each todo
 - **FR-010**: System MUST register as an `extension` plugin type in the plugin registry

--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,7 @@ COPY storage_api.py .
 COPY sheets_storage.py .
 COPY json_storage_core.py .
 COPY json_google_drive_storage.py .
+COPY todos_plugin.py .
 COPY transports/ transports/
 COPY templates/ templates/
 COPY static/ static/

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ import json_google_drive_storage
 import plugin_registry
 import sheets_storage
 import storage_api
+import todos_plugin
 from storage_api import StorageUnavailable
 
 # Register built-in plugins
@@ -41,6 +42,8 @@ plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLU
 plugin_registry.register(
     "storage", "json-google-drive", json_google_drive_storage, json_google_drive_storage.PLUGIN_METADATA
 )
+plugin_registry.register("extension", "todos", todos_plugin, todos_plugin.PLUGIN_METADATA)
+plugin_registry.activate_extension("todos")
 plugin_registry.activate_storage("sheets")
 
 app = Flask(__name__)
@@ -830,6 +833,14 @@ def api_toggle_plugin():
                 return jsonify({"error": str(e)}), HTTPStatus.BAD_REQUEST
         else:
             plugin_registry.deactivate_storage()
+    elif plugin_type == "extension":
+        try:
+            if enable:
+                plugin_registry.activate_extension(plugin_id)
+            else:
+                plugin_registry.deactivate_extension(plugin_id)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), HTTPStatus.BAD_REQUEST
     else:
         return jsonify({"error": f"Toggle not yet supported for type: {plugin_type}"}), HTTPStatus.BAD_REQUEST
 
@@ -1058,6 +1069,48 @@ def proxy_clear_sheets():
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
     except Exception as e:
         app.logger.error(f"Error in proxy_clear_sheets: {e}")
+        return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@app.route("/api/todos/sync", methods=["GET"])
+def api_get_todos():
+    """Download todos from Google Drive — stateless."""
+    if not is_logged_in():
+        return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
+    try:
+        credentials = get_credentials()
+        if not credentials:
+            return jsonify({"error": "No credentials"}), HTTPStatus.UNAUTHORIZED
+        request_creds = get_credentials_from_request()
+        folder_id = request_creds.get("folder_id") if request_creds else None
+        if not folder_id:
+            return jsonify({"todos": [], "lists": []})
+        drive_service = build("drive", "v3", credentials=credentials)
+        data = todos_plugin.read_todos(drive_service, folder_id)
+        return jsonify(data)
+    except HttpError as e:
+        return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@app.route("/api/todos/sync", methods=["POST"])
+def api_save_todos():
+    """Upload todos to Google Drive (full replace) — stateless."""
+    if not is_logged_in():
+        return jsonify({"error": "Not logged in"}), HTTPStatus.UNAUTHORIZED
+    try:
+        credentials = get_credentials()
+        if not credentials:
+            return jsonify({"error": "No credentials"}), HTTPStatus.UNAUTHORIZED
+        payload = get_request_data()
+        request_creds = get_credentials_from_request()
+        folder_id = request_creds.get("folder_id") if request_creds else None
+        if not folder_id:
+            return jsonify({"error": "No folder_id configured"}), HTTPStatus.BAD_REQUEST
+        drive_service = build("drive", "v3", credentials=credentials)
+        data = {"todos": payload.get("todos", []), "lists": payload.get("lists", [])}
+        todos_plugin.write_todos(drive_service, folder_id, data)
+        return jsonify({"status": "ok"})
+    except HttpError as e:
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
 
 

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -95,6 +95,20 @@ def get_active_storage_id():
     return _active_storage
 
 
+def activate_extension(plugin_id):
+    """Enable an extension plugin."""
+    if "extension" not in _plugins or plugin_id not in _plugins["extension"]:
+        raise ValueError(f"Extension plugin not registered: {plugin_id}")
+    _plugins["extension"][plugin_id]["active"] = True
+
+
+def deactivate_extension(plugin_id):
+    """Disable an extension plugin."""
+    if "extension" not in _plugins or plugin_id not in _plugins["extension"]:
+        raise ValueError(f"Extension plugin not registered: {plugin_id}")
+    _plugins["extension"][plugin_id]["active"] = False
+
+
 def get_plugin(plugin_type, plugin_id):
     """Get a specific plugin's module by type and id."""
     if plugin_type in _plugins and plugin_id in _plugins[plugin_type]:

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -16,7 +16,7 @@
 
     // IndexedDB configuration
     const DB_NAME = 'acquacotta';
-    const DB_VERSION = 2;  // Bumped for auth store
+    const DB_VERSION = 3;  // Bumped for todos stores
 
     // Object store names
     const STORES = {
@@ -24,7 +24,9 @@
         SETTINGS: 'settings',
         SYNC_QUEUE: 'sync_queue',
         SYNC_STATUS: 'sync_status',
-        AUTH: 'auth'
+        AUTH: 'auth',
+        TODOS: 'todos',
+        TODO_LISTS: 'todo_lists'
     };
 
     // Default settings (mirrors backend defaults)
@@ -141,6 +143,18 @@
                 // Auth store (for OAuth credentials - keeps server stateless)
                 if (!database.objectStoreNames.contains(STORES.AUTH)) {
                     database.createObjectStore(STORES.AUTH, { keyPath: 'key' });
+                }
+
+                // Todos store
+                if (!database.objectStoreNames.contains(STORES.TODOS)) {
+                    const todosStore = database.createObjectStore(STORES.TODOS, { keyPath: 'id' });
+                    todosStore.createIndex('list_id', 'list_id', { unique: false });
+                    todosStore.createIndex('status', 'status', { unique: false });
+                }
+
+                // Todo lists store
+                if (!database.objectStoreNames.contains(STORES.TODO_LISTS)) {
+                    database.createObjectStore(STORES.TODO_LISTS, { keyPath: 'id' });
                 }
             };
         });
@@ -1012,6 +1026,7 @@
                 end_time: endTime.toISOString(),
                 duration_minutes: data.duration_minutes || 25,
                 notes: data.notes || null,
+                linked_todo_id: data.linked_todo_id || null,
                 synced: false
             };
 
@@ -1040,6 +1055,7 @@
                 end_time: data.end_time,
                 duration_minutes: data.duration_minutes,
                 notes: data.notes || null,
+                linked_todo_id: data.linked_todo_id || null,
                 synced: false
             };
 
@@ -1480,6 +1496,183 @@
                 console.error('Error migrating settings:', e);
                 return { migrated: false, error: e.message };
             }
+        },
+
+        // ── Todos CRUD ──────────────────────────────────────────────
+
+        getTodos: async function() {
+            const todos = await getAllFromStore(STORES.TODOS);
+            return todos.sort((a, b) => {
+                if (a.status !== b.status) return a.status === 'pending' ? -1 : 1;
+                const now = new Date().toISOString().slice(0, 10);
+                const aOverdue = a.due_date && a.due_date < now && a.status === 'pending';
+                const bOverdue = b.due_date && b.due_date < now && b.status === 'pending';
+                if (aOverdue !== bOverdue) return aOverdue ? -1 : 1;
+                const priOrder = { high: 0, medium: 1, low: 2, none: 3 };
+                const aPri = priOrder[a.priority] ?? 3;
+                const bPri = priOrder[b.priority] ?? 3;
+                if (aPri !== bPri) return aPri - bPri;
+                return new Date(a.created_at) - new Date(b.created_at);
+            });
+        },
+
+        createTodo: async function(data) {
+            const todo = {
+                id: generateUUID(),
+                title: data.title || '',
+                notes: data.notes || '',
+                status: 'pending',
+                priority: data.priority || 'none',
+                due_date: data.due_date || null,
+                list_id: data.list_id || null,
+                created_at: new Date().toISOString(),
+                completed_at: null
+            };
+            await putInStore(STORES.TODOS, todo);
+            this._debounceTodoSync();
+            return todo;
+        },
+
+        updateTodo: async function(id, data) {
+            const existing = await getFromStore(STORES.TODOS, id);
+            if (!existing) return null;
+            const updated = { ...existing, ...data };
+            await putInStore(STORES.TODOS, updated);
+            this._debounceTodoSync();
+            return updated;
+        },
+
+        completeTodo: async function(id) {
+            const existing = await getFromStore(STORES.TODOS, id);
+            if (!existing) return null;
+            existing.status = 'completed';
+            existing.completed_at = new Date().toISOString();
+            await putInStore(STORES.TODOS, existing);
+            this._debounceTodoSync();
+            return existing;
+        },
+
+        uncompleteTodo: async function(id) {
+            const existing = await getFromStore(STORES.TODOS, id);
+            if (!existing) return null;
+            existing.status = 'pending';
+            existing.completed_at = null;
+            await putInStore(STORES.TODOS, existing);
+            this._debounceTodoSync();
+            return existing;
+        },
+
+        deleteTodo: async function(id) {
+            await deleteFromStore(STORES.TODOS, id);
+            this._debounceTodoSync();
+            return { status: 'ok' };
+        },
+
+        // ── Todo Lists CRUD ─────────────────────────────────────────
+
+        getTodoLists: async function() {
+            const lists = await getAllFromStore(STORES.TODO_LISTS);
+            return lists.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+        },
+
+        createTodoList: async function(data) {
+            const lists = await getAllFromStore(STORES.TODO_LISTS);
+            const list = {
+                id: generateUUID(),
+                name: data.name || 'New List',
+                order: lists.length
+            };
+            await putInStore(STORES.TODO_LISTS, list);
+            this._debounceTodoSync();
+            return list;
+        },
+
+        updateTodoList: async function(id, data) {
+            const existing = await getFromStore(STORES.TODO_LISTS, id);
+            if (!existing) return null;
+            const updated = { ...existing, ...data };
+            await putInStore(STORES.TODO_LISTS, updated);
+            this._debounceTodoSync();
+            return updated;
+        },
+
+        deleteTodoList: async function(id) {
+            await deleteFromStore(STORES.TODO_LISTS, id);
+            // Orphan todos in this list → set list_id to null
+            const todos = await getAllFromStore(STORES.TODOS);
+            for (const todo of todos) {
+                if (todo.list_id === id) {
+                    todo.list_id = null;
+                    await putInStore(STORES.TODOS, todo);
+                }
+            }
+            this._debounceTodoSync();
+            return { status: 'ok' };
+        },
+
+        // ── Todos Sync ──────────────────────────────────────────────
+
+        _todoSyncTimer: null,
+
+        _debounceTodoSync: function() {
+            if (this._todoSyncTimer) clearTimeout(this._todoSyncTimer);
+            if (!authStatus || !authStatus.logged_in || !isOnline) return;
+            this._todoSyncTimer = setTimeout(() => this.syncTodosToCloud(), 2000);
+        },
+
+        syncTodosToCloud: async function() {
+            if (!authStatus || !authStatus.logged_in || !isOnline) return;
+            try {
+                const todos = await getAllFromStore(STORES.TODOS);
+                const lists = await getAllFromStore(STORES.TODO_LISTS);
+                await authenticatedFetch('/api/todos/sync', {
+                    method: 'POST',
+                    body: JSON.stringify({ todos, lists })
+                });
+            } catch (e) {
+                console.error('Todo sync to cloud failed:', e);
+            }
+        },
+
+        loadTodosFromCloud: async function() {
+            if (!authStatus || !authStatus.logged_in || !isOnline) return false;
+            try {
+                const res = await authenticatedFetch('/api/todos/sync');
+                if (!res.ok) return false;
+                const data = await res.json();
+                if (data.todos) {
+                    for (const todo of data.todos) {
+                        await putInStore(STORES.TODOS, todo);
+                    }
+                }
+                if (data.lists) {
+                    for (const list of data.lists) {
+                        await putInStore(STORES.TODO_LISTS, list);
+                    }
+                }
+                return true;
+            } catch (e) {
+                console.error('Todo load from cloud failed:', e);
+                return false;
+            }
+        },
+
+        getLinkedTodoTime: async function(todoId) {
+            const pomodoros = await getAllFromStore(STORES.POMODOROS);
+            return pomodoros
+                .filter(p => p.linked_todo_id === todoId)
+                .reduce((sum, p) => sum + (p.duration_minutes || 0), 0);
+        },
+
+        buildTodoTimeMap: async function() {
+            const pomodoros = await getAllFromStore(STORES.POMODOROS);
+            const map = {};
+            for (const p of pomodoros) {
+                if (p.linked_todo_id) {
+                    map[p.linked_todo_id] = (map[p.linked_todo_id] || 0) + (p.duration_minutes || 0);
+                }
+            }
+            return map;
         }
     };
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -243,6 +243,66 @@
         }
         .type-item button:hover { color: var(--accent); }
 
+        /* Todos */
+        .todo-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+        .todo-header h2 { margin: 0; }
+        .todo-lists-bar {
+            display: flex; gap: 0.5rem; background: var(--bg-secondary);
+            padding: 0.25rem; border-radius: 8px; margin-bottom: 1rem; flex-wrap: wrap;
+        }
+        .todo-lists-bar button {
+            padding: 0.5rem 1rem; background: transparent; border: none;
+            color: var(--text-secondary); cursor: pointer; border-radius: 6px; font-size: 0.875rem;
+            white-space: nowrap;
+        }
+        .todo-lists-bar button:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+        .todo-lists-bar button.active { background: var(--bg-tertiary); color: var(--text-primary); font-weight: 600; }
+        .todo-item {
+            display: flex; align-items: flex-start; gap: 0.75rem;
+            padding: 0.75rem 1rem; background: var(--bg-secondary); border-radius: 8px;
+            margin-bottom: 0.5rem; transition: background 0.2s;
+        }
+        .todo-item:hover { background: var(--bg-tertiary); cursor: pointer; }
+        .todo-item.completed .todo-title { text-decoration: line-through; color: var(--text-secondary); }
+        .todo-checkbox {
+            width: 20px; height: 20px; min-width: 20px; border-radius: 50%;
+            border: 2px solid var(--text-secondary); background: transparent;
+            cursor: pointer; margin-top: 2px; transition: all 0.2s; padding: 0;
+        }
+        .todo-checkbox:hover { border-color: var(--accent); }
+        .todo-checkbox.checked { background: var(--success); border-color: var(--success); }
+        .todo-content { flex: 1; min-width: 0; }
+        .todo-title { font-weight: 500; word-break: break-word; }
+        .todo-meta { font-size: 0.8rem; color: var(--text-secondary); margin-top: 0.25rem; display: flex; gap: 0.75rem; flex-wrap: wrap; }
+        .todo-priority {
+            display: inline-block; font-size: 0.7rem; padding: 0.15rem 0.5rem;
+            border-radius: 4px; font-weight: 600; text-transform: uppercase;
+        }
+        .todo-priority.high { background: rgba(233, 69, 96, 0.2); color: var(--accent); }
+        .todo-priority.medium { background: rgba(255, 193, 7, 0.2); color: #ffc107; }
+        .todo-priority.low { background: rgba(78, 204, 163, 0.2); color: var(--success); }
+        .todo-due { font-size: 0.8rem; }
+        .todo-due.overdue { color: var(--accent); font-weight: 600; }
+        .todo-time { font-size: 0.8rem; color: var(--success); }
+        .todo-actions { display: flex; gap: 0.25rem; align-items: flex-start; }
+        .todo-actions button {
+            background: none; border: none; color: var(--text-secondary);
+            cursor: pointer; padding: 0.25rem 0.5rem; font-size: 1rem;
+        }
+        .todo-actions button:hover { color: var(--text-primary); }
+        .todo-add-form {
+            display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap;
+        }
+        .todo-add-form input[type="text"] { flex: 1; min-width: 200px; }
+        .todo-add-form select, .todo-add-form input[type="date"] { max-width: 150px; }
+        .todo-completed-header {
+            display: flex; align-items: center; gap: 0.5rem; cursor: pointer;
+            color: var(--text-secondary); margin-top: 1.5rem; margin-bottom: 0.5rem;
+            font-size: 0.875rem; user-select: none;
+        }
+        .todo-completed-header:hover { color: var(--text-primary); }
+        .todo-notes-preview { font-size: 0.8rem; color: var(--text-secondary); margin-top: 0.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 400px; }
+
         /* Weekly Overview */
         .weekly-overview {
             margin-top: 2rem;
@@ -481,7 +541,7 @@
         }
     </style>
     <script src="{{ url_for('static', filename='js/utils.js') }}?v=3"></script>
-    <script src="{{ url_for('static', filename='js/storage.js') }}?v=3"></script>
+    <script src="{{ url_for('static', filename='js/storage.js') }}?v=4"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -510,6 +570,7 @@
             <button class="active" data-view="timer" role="tab" aria-selected="true" aria-controls="timer-view" id="tab-timer" tabindex="0" title="Start a pomodoro timer or log completed work sessions">Timer</button>
             <button data-view="reports" role="tab" aria-selected="false" aria-controls="reports-view" id="tab-reports" tabindex="-1" title="View charts and statistics of your completed pomodoros">Reports</button>
             <button data-view="history" role="tab" aria-selected="false" aria-controls="history-view" id="tab-history" tabindex="-1" title="Browse and edit your pomodoro history">History</button>
+            <button data-view="todos" role="tab" aria-selected="false" aria-controls="todos-view" id="tab-todos" tabindex="-1" title="Manage your to-do lists and tasks">To-do</button>
             <button data-view="settings" role="tab" aria-selected="false" aria-controls="settings-view" id="tab-settings" tabindex="-1" title="Configure timer presets, breaks, and display options">Settings</button>
         </nav>
 
@@ -677,6 +738,84 @@
             </div>
         </div>
 
+        <!-- Todos View -->
+        <div id="todos-view" class="view" role="tabpanel" aria-labelledby="tab-todos">
+            <div class="todo-header">
+                <h2>To-do</h2>
+                <button class="secondary" onclick="showListManager()" style="padding: 0.5rem 1rem; font-size: 0.875rem;" title="Create, rename, or delete lists">Manage Lists</button>
+            </div>
+            <div class="todo-lists-bar" id="todo-lists-bar"></div>
+            <div class="todo-add-form" id="todo-add-form">
+                <input type="text" id="todo-add-title" placeholder="Add a new to-do..." style="font-size: 0.875rem;">
+                <select id="todo-add-priority" style="font-size: 0.875rem;">
+                    <option value="none">Priority</option>
+                    <option value="high">High</option>
+                    <option value="medium">Medium</option>
+                    <option value="low">Low</option>
+                </select>
+                <input type="date" id="todo-add-due" style="font-size: 0.875rem;">
+                <button class="primary" onclick="addTodo()" style="padding: 0.5rem 1rem; font-size: 0.875rem;">Add</button>
+            </div>
+            <div id="todo-list-container"></div>
+            <div class="todo-completed-header" id="todo-completed-toggle" onclick="toggleCompletedTodos()" style="display:none;">
+                <span id="todo-completed-arrow">&#9654;</span>
+                <span>Completed (<span id="todo-completed-count">0</span>)</span>
+            </div>
+            <div id="todo-completed-container" style="display:none;"></div>
+        </div>
+
+        <!-- Todo Edit Modal -->
+        <div class="modal-overlay" id="todo-edit-modal">
+            <div class="modal">
+                <h2>Edit To-do</h2>
+                <input type="hidden" id="todo-edit-id">
+                <div class="form-group">
+                    <label for="todo-edit-title">Title</label>
+                    <input type="text" id="todo-edit-title">
+                </div>
+                <div class="form-group">
+                    <label for="todo-edit-notes">Notes</label>
+                    <textarea id="todo-edit-notes" rows="3" style="resize: vertical;"></textarea>
+                </div>
+                <div class="form-group">
+                    <label for="todo-edit-priority">Priority</label>
+                    <select id="todo-edit-priority">
+                        <option value="none">None</option>
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="todo-edit-due">Due Date</label>
+                    <input type="date" id="todo-edit-due">
+                </div>
+                <div class="form-group">
+                    <label for="todo-edit-list">List</label>
+                    <select id="todo-edit-list"></select>
+                </div>
+                <div class="modal-actions">
+                    <button class="secondary" onclick="closeTodoEditModal()">Cancel</button>
+                    <button class="primary" onclick="saveTodoEdit()">Save</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- List Manager Modal -->
+        <div class="modal-overlay" id="list-manager-modal">
+            <div class="modal">
+                <h2>Manage Lists</h2>
+                <div id="list-manager-items"></div>
+                <div style="display:flex; gap:0.5rem; margin-top:1rem;">
+                    <input type="text" id="list-add-name" placeholder="New list name..." style="font-size: 0.875rem;">
+                    <button class="primary" onclick="addTodoList()" style="padding: 0.5rem 1rem; font-size: 0.875rem;">Add</button>
+                </div>
+                <div class="modal-actions">
+                    <button class="secondary" onclick="closeListManager()">Done</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Settings View -->
         <div id="settings-view" class="view" role="tabpanel" aria-labelledby="tab-settings">
             <h2>Settings</h2>
@@ -711,10 +850,7 @@
                     <p id="cloud-sync-status-text" style="color: var(--success); font-size: 0.875rem; margin-bottom: 1rem;">
                         ✓ Data synced to Google Drive
                     </p>
-                    <div style="margin-bottom: 1rem;">
-                        <span style="font-size: 0.875rem; color: var(--text-secondary);">Pomodoros stored: </span>
-                        <span id="google-pomodoro-count" style="font-weight: 500; color: var(--accent);">0</span>
-                    </div>
+                    <div id="cloud-data-counts" style="margin-bottom: 1rem;"></div>
                     <div id="location-field-section">
                         <label id="location-field-label" for="storage-location-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Storage Location:</label>
                         <div style="display: inline-grid; grid-template-columns: 1fr auto; gap: 0.5rem; margin-bottom: 1rem;">
@@ -733,18 +869,12 @@
                 </div>
             </div>
             <div class="card" id="local-data-card" style="display: none;">
-                <h3>Local Data</h3>
+                <h3>Local Data: Browser</h3>
                 <p style="color: var(--text-secondary); font-size: 0.875rem; margin-bottom: 1rem;">
                     Your data is stored locally on this device. Sign in with Google to sync across devices.
                 </p>
-                <div style="margin-bottom: 1rem;">
-                    <span style="font-size: 0.875rem; color: var(--text-secondary);">Pomodoros stored: </span>
-                    <span id="local-pomodoro-count" style="font-weight: 500; color: var(--accent);">0</span>
-                </div>
-                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                    <button class="secondary" onclick="downloadLocalData()">Download CSV</button>
-                    <button class="secondary" onclick="document.getElementById('csv-upload-input').click()">Upload CSV</button>
-                    <input type="file" id="csv-upload-input" accept=".csv" style="display: none;" onchange="uploadCSV(this)">
+                <div id="local-data-rows"></div>
+                <div style="margin-top: 0.75rem;">
                     <button class="secondary" onclick="confirmClearLocalData()" style="color: #ef4444;">Clear All Data</button>
                 </div>
                 <p id="local-data-status" style="font-size: 0.875rem; margin-top: 0.5rem; display: none;"></p>
@@ -2045,6 +2175,7 @@
                 if (btn.dataset.view === 'timer') loadWeeklyOverview();
                 if (btn.dataset.view === 'history') loadHistory();
                 if (btn.dataset.view === 'reports') loadReport();
+                if (btn.dataset.view === 'todos') loadTodos();
             });
         });
 
@@ -2052,7 +2183,7 @@
         function switchToViewFromURL() {
             const params = new URLSearchParams(window.location.search);
             const view = params.get('view');
-            if (view && ['timer', 'reports', 'history', 'settings'].includes(view)) {
+            if (view && ['timer', 'reports', 'history', 'todos', 'settings'].includes(view)) {
                 document.querySelectorAll('nav button').forEach(b => {
                     b.classList.remove('active');
                     b.setAttribute('aria-selected', 'false');
@@ -2398,11 +2529,14 @@
         async function savePomodoro() {
             const name = document.getElementById('timer-pomo-name').value.trim();
 
+            const typeValue = document.getElementById('timer-pomo-type').value;
+            const { type: resolvedType, linked_todo_id } = parseTypeValue(typeValue);
             await Storage.createPomodoro({
                 name,
-                type: document.getElementById('timer-pomo-type').value,
+                type: resolvedType,
                 duration_minutes: Math.round(totalSeconds / 60),
-                notes: document.getElementById('timer-pomo-notes').value.trim() || null
+                notes: document.getElementById('timer-pomo-notes').value.trim() || null,
+                linked_todo_id
             });
 
             // Keep fields visible during break (stored in lastPomodoro for auto-start)
@@ -2705,6 +2839,15 @@
                     return;
                 }
 
+                // Build todo title map for linked pomodoros
+                const historyTodoMap = {};
+                const allTodos = await Storage.getTodos();
+                const allLists = await Storage.getTodoLists();
+                for (const t of allTodos) {
+                    const listName = allLists.find(l => l.id === t.list_id)?.name;
+                    historyTodoMap[t.id] = listName ? `${listName} > ${t.title}` : t.title;
+                }
+
                 // Group by date (using configured timezone)
                 const grouped = {};
                 pomodoros.forEach(p => {
@@ -2722,12 +2865,14 @@
                         const color = TYPE_COLORS[p.type] || '#6b7280';
                         const time = new Date(p.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: tz });
                         const safeId = escapeHtml(p.id);
+                        const linkedInfo = p.linked_todo_id && historyTodoMap[p.linked_todo_id]
+                            ? ` &middot; <span style="color:var(--success);">${escapeHtml(historyTodoMap[p.linked_todo_id])}</span>` : '';
                         html += `
                             <div class="pomodoro-item" data-id="${safeId}">
                                 <div>
                                     <span class="pomodoro-name">${escapeHtml(p.name)}</span>
                                     <span class="pomodoro-type" style="background:${color}20;color:${color}">${escapeHtml(p.type)}</span>
-                                    <div class="pomodoro-meta">${time} - ${p.duration_minutes} min</div>
+                                    <div class="pomodoro-meta">${time} - ${p.duration_minutes} min${linkedInfo}</div>
                                 </div>
                                 <div class="pomodoro-actions">
                                     <button class="delete-btn" title="Delete">&#10005;</button>
@@ -3033,13 +3178,15 @@
                 }
 
                 // Create all pomodoros
+                const { type: resolvedType, linked_todo_id } = parseTypeValue(type);
                 for (const slot of slots) {
                     await Storage.createManualPomodoro({
                         name,
-                        type,
+                        type: resolvedType,
                         start_time: slot.start.toISOString(),
                         end_time: slot.end.toISOString(),
-                        duration_minutes: duration
+                        duration_minutes: duration,
+                        linked_todo_id
                     });
                 }
 
@@ -3581,6 +3728,7 @@
                 }).join('');
 
                 updateSyncCardVisibility(data.active_storage);
+                updateExtensionTabs(data.plugins);
             } catch (e) {
                 loading.textContent = 'Could not load plugins';
             }
@@ -3609,8 +3757,23 @@
                 updateSyncCardVisibility(data.active_storage);
                 updateAuthUI();
                 loadPlugins();
+                fetch('/api/plugins').then(r => r.json()).then(d => updateExtensionTabs(d.plugins));
             } catch (e) {
                 checkbox.checked = !enable;
+            }
+        }
+
+        function updateExtensionTabs(plugins) {
+            const todosTab = document.getElementById('tab-todos');
+            const todosPlugin = plugins && plugins.find(p => p.id === 'todos' && p.plugin_type === 'extension');
+            if (todosTab) {
+                todosTab.style.display = (todosPlugin && todosPlugin.active) ? '' : 'none';
+                if (todosPlugin && !todosPlugin.active) {
+                    const todosView = document.getElementById('todos-view');
+                    if (todosView && todosView.classList.contains('active')) {
+                        document.getElementById('tab-timer').click();
+                    }
+                }
             }
         }
 
@@ -3817,20 +3980,86 @@
         }
 
         // Type management functions
-        function populateTypeDropdowns() {
+        // Cached plugin list data for the cascading type dropdown
+        let _typeDropdownTodoLists = [];
+        let _typeDropdownTodos = [];
+        let _typeDropdownTodosActive = false;
+
+        async function populateTypeDropdowns() {
             const types = settings.pomodoro_types || [];
-            // Ensure all types are strings
             const stringTypes = types.map(t => String(t)).filter(t => t && t.trim());
+
+            // Fetch todo lists for the cascading dropdown
+            _typeDropdownTodoLists = [];
+            _typeDropdownTodos = [];
+            _typeDropdownTodosActive = false;
+            try {
+                const pluginRes = await fetch('/api/plugins');
+                const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
+                const todosPlugin = pluginData.plugins.find(p => p.id === 'todos' && p.active);
+                if (todosPlugin) {
+                    _typeDropdownTodosActive = true;
+                    _typeDropdownTodoLists = await Storage.getTodoLists();
+                    _typeDropdownTodos = (await Storage.getTodos()).filter(t => t.status === 'pending');
+                }
+            } catch (e) { /* offline */ }
+
             const selects = ['pomo-type', 'add-type', 'timer-pomo-type', 'edit-type'];
             selects.forEach(id => {
                 const select = document.getElementById(id);
                 if (!select) return;
-                const currentValue = select.value;
-                select.innerHTML = stringTypes.map(t => `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`).join('');
-                if (currentValue && stringTypes.includes(currentValue)) {
-                    select.value = currentValue;
+                renderTypeDropdownTopLevel(select, stringTypes);
+                if (!select.dataset.cascadeAttached) {
+                    select.addEventListener('change', () => onTypeDropdownChange(select, stringTypes));
+                    select.addEventListener('mousedown', () => onTypeDropdownFocus(select, stringTypes));
+                    select.dataset.cascadeAttached = 'true';
                 }
             });
+        }
+
+        function renderTypeDropdownTopLevel(select, stringTypes, preserveValue) {
+            const currentValue = preserveValue || select.value;
+            let html = stringTypes.map(t => `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`).join('');
+
+            if (_typeDropdownTodosActive && _typeDropdownTodoLists.length > 0) {
+                html += '<option disabled>──────────</option>';
+                for (const list of _typeDropdownTodoLists) {
+                    const count = _typeDropdownTodos.filter(t => t.list_id === list.id).length;
+                    if (count === 0) continue;
+                    html += `<option value="list:${list.id}">📋 ${escapeHtml(list.name)} (${count})</option>`;
+                }
+            }
+
+            select.innerHTML = html;
+            if (currentValue && !currentValue.startsWith('todo:') && !currentValue.startsWith('list:')) {
+                const hasOption = Array.from(select.options).some(o => o.value === currentValue);
+                if (hasOption) select.value = currentValue;
+            }
+        }
+
+        function onTypeDropdownChange(select, stringTypes) {
+            const value = select.value;
+            if (value && value.startsWith('list:')) {
+                const listId = value.slice(5);
+                const listTodos = _typeDropdownTodos.filter(t => t.list_id === listId);
+                const list = _typeDropdownTodoLists.find(l => l.id === listId);
+                const label = list ? list.name : 'To-do';
+                let html = `<option value="" disabled selected>Select from ${escapeHtml(label)}...</option>`;
+                for (const t of listTodos) {
+                    html += `<option value="todo:${t.id}">${escapeHtml(t.title)}</option>`;
+                }
+                select.innerHTML = html;
+                // Auto-reopen so the user doesn't need a second click
+                requestAnimationFrame(() => {
+                    try { select.showPicker(); } catch (e) { /* fallback: user clicks again */ }
+                });
+            }
+        }
+
+        function onTypeDropdownFocus(select, stringTypes) {
+            if (select.value && select.value.startsWith('todo:')) {
+                renderTypeDropdownTopLevel(select, stringTypes);
+            }
         }
 
         function renderTypesList() {
@@ -4089,33 +4318,85 @@
 
         // Update local pomodoro count display
         async function updateLocalPomodoroCount() {
-            const countEl = document.getElementById('local-pomodoro-count');
-            if (countEl) {
-                const count = await Storage.getLocalPomodoroCount();
-                countEl.textContent = count;
-            }
+            const container = document.getElementById('local-data-rows');
+            if (!container) return;
+
+            const pomoCount = await Storage.getLocalPomodoroCount();
+            const todos = await Storage.getTodos();
+
+            let html = `<div style="display: flex; align-items: center; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px solid var(--bg-tertiary);">
+                <div><span style="font-size: 0.875rem; color: var(--text-secondary);">Pomodoros: </span><span style="font-weight: 500; color: var(--accent);">${pomoCount}</span></div>
+                <div style="display: flex; gap: 0.5rem;">
+                    <button class="secondary" onclick="downloadLocalData()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Export CSV</button>
+                    <button class="secondary" onclick="document.getElementById('csv-upload-input').click()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Import CSV</button>
+                    <input type="file" id="csv-upload-input" accept=".csv" style="display: none;" onchange="uploadCSV(this)">
+                </div>
+            </div>`;
+
+            // Todos row (if plugin active)
+            try {
+                const pluginRes = await fetch('/api/plugins');
+                const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
+                const todosActive = pluginData.plugins.find(p => p.id === 'todos' && p.active);
+                if (todosActive) {
+                    html += `<div style="display: flex; align-items: center; justify-content: space-between; padding: 0.5rem 0;">
+                        <div><span style="font-size: 0.875rem; color: var(--text-secondary);">Todos: </span><span style="font-weight: 500; color: var(--accent);">${todos.length}</span></div>
+                        <div style="display: flex; gap: 0.5rem;">
+                            <button class="secondary" onclick="exportTodoCSV()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Export CSV</button>
+                            <button class="secondary" onclick="document.getElementById('todo-csv-upload').click()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Import CSV</button>
+                            <input type="file" id="todo-csv-upload" accept=".csv" style="display: none;" onchange="importTodoCSV(this)">
+                        </div>
+                    </div>`;
+                }
+            } catch (e) { /* offline */ }
+
+            container.innerHTML = html;
         }
 
-        // Update Google Sheets pomodoro count display
-        // Uses efficient count endpoint that only fetches IDs, not all data
         async function updateGooglePomodoroCount() {
-            const countEl = document.getElementById('google-pomodoro-count');
-            if (countEl && authStatus.logged_in) {
-                // Use locally-known count from init sync if available (avoids stale Drive reads)
-                if (authStatus.synced_count != null) {
-                    countEl.textContent = authStatus.synced_count;
-                    return;
-                }
+            const container = document.getElementById('cloud-data-counts');
+            if (!container || !authStatus.logged_in) return;
+
+            let pomoCount = 0;
+            if (authStatus.synced_count != null) {
+                pomoCount = authStatus.synced_count;
+            } else {
                 try {
                     const res = await Storage.authenticatedFetch('/api/sheets/pomodoros/count');
                     if (res.ok) {
                         const data = await res.json();
-                        countEl.textContent = data.count || 0;
+                        pomoCount = data.count || 0;
                     }
-                } catch (e) {
-                    console.error('Error fetching Google pomodoro count:', e);
-                }
+                } catch (e) { /* offline */ }
             }
+
+            let html = `<div style="display: flex; align-items: center; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px solid var(--bg-tertiary);">
+                <div><span style="font-size: 0.875rem; color: var(--text-secondary);">Pomodoros: </span><span style="font-weight: 500; color: var(--accent);">${pomoCount}</span></div>
+                <div style="display: flex; gap: 0.5rem;">
+                    <button class="secondary" onclick="downloadLocalData()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Export CSV</button>
+                    <button class="secondary" onclick="document.getElementById('cloud-csv-upload-pomo').click()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Import CSV</button>
+                    <input type="file" id="cloud-csv-upload-pomo" accept=".csv" style="display: none;" onchange="uploadCSV(this)">
+                </div>
+            </div>`;
+
+            try {
+                const pluginRes = await fetch('/api/plugins');
+                const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
+                const todosActive = pluginData.plugins.find(p => p.id === 'todos' && p.active);
+                if (todosActive) {
+                    const todos = await Storage.getTodos();
+                    html += `<div style="display: flex; align-items: center; justify-content: space-between; padding: 0.5rem 0;">
+                        <div><span style="font-size: 0.875rem; color: var(--text-secondary);">Todos: </span><span style="font-weight: 500; color: var(--accent);">${todos.length}</span></div>
+                        <div style="display: flex; gap: 0.5rem;">
+                            <button class="secondary" onclick="exportTodoCSV()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Export CSV</button>
+                            <button class="secondary" onclick="document.getElementById('cloud-csv-upload-todo').click()" style="padding: 0.25rem 0.75rem; font-size: 0.75rem;">Import CSV</button>
+                            <input type="file" id="cloud-csv-upload-todo" accept=".csv" style="display: none;" onchange="importTodoCSV(this)">
+                        </div>
+                    </div>`;
+                }
+            } catch (e) { /* offline */ }
+
+            container.innerHTML = html;
         }
 
         // Show local data migration modal
@@ -4519,7 +4800,8 @@
             const pluginName = activePluginInfo ? activePluginInfo.name : 'Google Sheets';
 
             // Update card title and sync status text
-            document.getElementById('cloud-sync-title').textContent = pluginName + ' Sync (Optional)';
+            const remoteLabel = isSheets ? 'Remote Data: Sheets' : isJsonDrive ? 'Remote Data: JSON-Google Drive' : 'Remote Data: ' + pluginName;
+            document.getElementById('cloud-sync-title').textContent = remoteLabel;
             document.getElementById('cloud-sync-status-text').textContent = '✓ Data synced to ' + pluginName;
 
             // Show spreadsheet ID input on login only for Sheets plugin
@@ -5018,10 +5300,356 @@
             }
         })();
 
+        // ── Todos ──────────────────────────────────────────────────
+
+        let todoSelectedListId = 'all';
+        let todoCompletedVisible = false;
+
+        function escTodo(s) { return escapeHtml(s); }
+
+        async function loadTodos() {
+            const lists = await Storage.getTodoLists();
+            const todos = await Storage.getTodos();
+
+            // Ensure at least one list exists
+            if (lists.length === 0) {
+                await Storage.createTodoList({ name: 'General' });
+                return loadTodos();
+            }
+
+            // Render list bar
+            const bar = document.getElementById('todo-lists-bar');
+            bar.innerHTML = `<button class="${todoSelectedListId === 'all' ? 'active' : ''}" onclick="selectTodoList('all')">All</button>` +
+                lists.map(l => `<button class="${todoSelectedListId === l.id ? 'active' : ''}" onclick="selectTodoList('${l.id}')">${escTodo(l.name)}</button>`).join('');
+
+            // Filter by selected list
+            const filtered = todoSelectedListId === 'all' ? todos : todos.filter(t => t.list_id === todoSelectedListId);
+            const pending = filtered.filter(t => t.status === 'pending');
+            const completed = filtered.filter(t => t.status === 'completed');
+
+            // Build time map once (single IndexedDB read of all pomodoros)
+            const pomodoroMap = await buildPomodoroTimeMap();
+
+            // Render pending todos
+            const container = document.getElementById('todo-list-container');
+            if (pending.length === 0 && completed.length === 0) {
+                container.innerHTML = '<div class="empty">No to-dos yet. Add one above.</div>';
+            } else {
+                container.innerHTML = pending.map(t => renderTodoItem(t, lists, pomodoroMap)).join('');
+            }
+
+            // Completed section
+            const toggle = document.getElementById('todo-completed-toggle');
+            const compContainer = document.getElementById('todo-completed-container');
+            if (completed.length > 0) {
+                toggle.style.display = 'flex';
+                document.getElementById('todo-completed-count').textContent = completed.length;
+                document.getElementById('todo-completed-arrow').innerHTML = todoCompletedVisible ? '&#9660;' : '&#9654;';
+                if (todoCompletedVisible) {
+                    compContainer.style.display = 'block';
+                    compContainer.innerHTML = completed.map(t => renderTodoItem(t, lists, pomodoroMap)).join('');
+                } else {
+                    compContainer.style.display = 'none';
+                }
+            } else {
+                toggle.style.display = 'none';
+                compContainer.style.display = 'none';
+            }
+
+            // Populate edit modal list dropdown
+            const editListSelect = document.getElementById('todo-edit-list');
+            editListSelect.innerHTML = lists.map(l => `<option value="${l.id}">${escTodo(l.name)}</option>`).join('');
+
+            // Refresh type dropdowns so todo items are current
+            await populateTypeDropdowns();
+        }
+
+        async function buildPomodoroTimeMap() {
+            return Storage.buildTodoTimeMap();
+        }
+
+        function renderTodoItem(todo, lists, pomodoroMap) {
+            const isCompleted = todo.status === 'completed';
+            const listName = lists.find(l => l.id === todo.list_id)?.name || '';
+            const today = new Date().toISOString().slice(0, 10);
+            const isOverdue = todo.due_date && todo.due_date < today && !isCompleted;
+            const timeMinutes = pomodoroMap[todo.id] || 0;
+
+            let metaParts = [];
+            if (todo.priority && todo.priority !== 'none') {
+                metaParts.push(`<span class="todo-priority ${todo.priority}">${todo.priority}</span>`);
+            }
+            if (todo.due_date) {
+                metaParts.push(`<span class="todo-due ${isOverdue ? 'overdue' : ''}">${isOverdue ? 'Overdue: ' : 'Due: '}${todo.due_date}</span>`);
+            }
+            if (timeMinutes > 0) {
+                const hrs = Math.floor(timeMinutes / 60);
+                const mins = timeMinutes % 60;
+                metaParts.push(`<span class="todo-time">${hrs > 0 ? hrs + 'h ' : ''}${mins}m tracked</span>`);
+            }
+            if (listName && todoSelectedListId === 'all') {
+                metaParts.push(`<span>${escTodo(listName)}</span>`);
+            }
+
+            return `<div class="todo-item ${isCompleted ? 'completed' : ''}" onclick="editTodo('${todo.id}')">
+                <button class="todo-checkbox ${isCompleted ? 'checked' : ''}" onclick="event.stopPropagation(); toggleTodo('${todo.id}')" aria-label="${isCompleted ? 'Mark incomplete' : 'Mark complete'}"></button>
+                <div class="todo-content">
+                    <div class="todo-title">${escTodo(todo.title)}</div>
+                    ${todo.notes ? `<div class="todo-notes-preview">${escTodo(todo.notes)}</div>` : ''}
+                    ${metaParts.length ? `<div class="todo-meta">${metaParts.join('')}</div>` : ''}
+                </div>
+                <div class="todo-actions">
+                    <button onclick="event.stopPropagation(); deleteTodoConfirm('${todo.id}')" title="Delete">&times;</button>
+                </div>
+            </div>`;
+        }
+
+        function selectTodoList(listId) {
+            todoSelectedListId = listId;
+            loadTodos();
+        }
+
+        async function addTodo() {
+            const titleInput = document.getElementById('todo-add-title');
+            const title = titleInput.value.trim();
+            if (!title) return;
+            const priority = document.getElementById('todo-add-priority').value;
+            const due = document.getElementById('todo-add-due').value || null;
+            const listId = todoSelectedListId === 'all' ? (await Storage.getTodoLists())[0]?.id : todoSelectedListId;
+            await Storage.createTodo({ title, priority, due_date: due, list_id: listId });
+            titleInput.value = '';
+            document.getElementById('todo-add-priority').value = 'none';
+            document.getElementById('todo-add-due').value = '';
+            loadTodos();
+        }
+
+        document.getElementById('todo-add-title').addEventListener('keydown', e => {
+            if (e.key === 'Enter') { e.preventDefault(); addTodo(); }
+        });
+
+        async function toggleTodo(id) {
+            const todos = await Storage.getTodos();
+            const todo = todos.find(t => t.id === id);
+            if (!todo) return;
+            if (todo.status === 'pending') {
+                await Storage.completeTodo(id);
+            } else {
+                await Storage.uncompleteTodo(id);
+            }
+            loadTodos();
+        }
+
+        async function editTodo(id) {
+            const todos = await Storage.getTodos();
+            const todo = todos.find(t => t.id === id);
+            if (!todo) return;
+            document.getElementById('todo-edit-id').value = id;
+            document.getElementById('todo-edit-title').value = todo.title;
+            document.getElementById('todo-edit-notes').value = todo.notes || '';
+            document.getElementById('todo-edit-priority').value = todo.priority || 'none';
+            document.getElementById('todo-edit-due').value = todo.due_date || '';
+            document.getElementById('todo-edit-list').value = todo.list_id || '';
+            document.getElementById('todo-edit-modal').classList.add('active');
+        }
+
+        function closeTodoEditModal() {
+            document.getElementById('todo-edit-modal').classList.remove('active');
+        }
+
+        async function saveTodoEdit() {
+            const id = document.getElementById('todo-edit-id').value;
+            await Storage.updateTodo(id, {
+                title: document.getElementById('todo-edit-title').value.trim(),
+                notes: document.getElementById('todo-edit-notes').value.trim(),
+                priority: document.getElementById('todo-edit-priority').value,
+                due_date: document.getElementById('todo-edit-due').value || null,
+                list_id: document.getElementById('todo-edit-list').value || null
+            });
+            closeTodoEditModal();
+            loadTodos();
+        }
+
+        async function deleteTodoConfirm(id) {
+            if (confirm('Delete this to-do?')) {
+                await Storage.deleteTodo(id);
+                loadTodos();
+            }
+        }
+
+        function toggleCompletedTodos() {
+            todoCompletedVisible = !todoCompletedVisible;
+            loadTodos();
+        }
+
+        // ── List Manager ──────────────────────────────────────────
+
+        async function showListManager() {
+            const lists = await Storage.getTodoLists();
+            const container = document.getElementById('list-manager-items');
+            container.innerHTML = lists.map(l => `
+                <div class="type-item" style="margin-bottom: 0.5rem;">
+                    <span>${escTodo(l.name)}</span>
+                    <div>
+                        <button onclick="renameList('${l.id}', '${escTodo(l.name)}')" title="Rename">&#9998;</button>
+                        <button onclick="deleteList('${l.id}')" title="Delete">&times;</button>
+                    </div>
+                </div>
+            `).join('');
+            document.getElementById('list-manager-modal').classList.add('active');
+        }
+
+        function closeListManager() {
+            document.getElementById('list-manager-modal').classList.remove('active');
+            loadTodos();
+        }
+
+        async function addTodoList() {
+            const input = document.getElementById('list-add-name');
+            const name = input.value.trim();
+            if (!name) return;
+            await Storage.createTodoList({ name });
+            input.value = '';
+            showListManager();
+        }
+
+        async function renameList(id, currentName) {
+            const newName = prompt('Rename list:', currentName);
+            if (newName && newName.trim()) {
+                await Storage.updateTodoList(id, { name: newName.trim() });
+                showListManager();
+            }
+        }
+
+        async function deleteList(id) {
+            const todos = await Storage.getTodos();
+            const count = todos.filter(t => t.list_id === id).length;
+            const msg = count > 0
+                ? `This list has ${count} to-do(s). They will become uncategorized. Delete?`
+                : 'Delete this list?';
+            if (confirm(msg)) {
+                await Storage.deleteTodoList(id);
+                if (todoSelectedListId === id) todoSelectedListId = 'all';
+                showListManager();
+            }
+        }
+
+        // ── Todo CSV Import/Export ─────────────────────────────────
+
+        async function exportTodoCSV() {
+            const todos = await Storage.getTodos();
+            const lists = await Storage.getTodoLists();
+            const listMap = {};
+            lists.forEach(l => { listMap[l.id] = l.name; });
+
+            const lines = ['title,list,priority,due_date,status,notes,created_at,completed_at'];
+            todos.forEach(t => {
+                const title = (t.title || '').replace(/"/g, '""');
+                const notes = (t.notes || '').replace(/"/g, '""');
+                const list = (listMap[t.list_id] || '').replace(/"/g, '""');
+                lines.push(`"${title}","${list}","${t.priority || 'none'}","${t.due_date || ''}","${t.status}","${notes}","${t.created_at || ''}","${t.completed_at || ''}"`);
+            });
+
+            const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'acquacotta_todos.csv';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }
+
+        async function importTodoCSV(input) {
+            const file = input.files[0];
+            if (!file) return;
+
+            try {
+                const text = await file.text();
+                const lines = text.trim().split('\n');
+                if (lines.length < 2) { alert('CSV file is empty'); return; }
+
+                function parseCSVLine(line) {
+                    const result = [];
+                    let current = '';
+                    let inQuotes = false;
+                    for (let i = 0; i < line.length; i++) {
+                        const char = line[i];
+                        if (char === '"') {
+                            if (inQuotes && line[i + 1] === '"') { current += '"'; i++; }
+                            else { inQuotes = !inQuotes; }
+                        } else if (char === ',' && !inQuotes) {
+                            result.push(current); current = '';
+                        } else { current += char; }
+                    }
+                    result.push(current);
+                    return result;
+                }
+
+                // Build list map — create lists that don't exist
+                const existingLists = await Storage.getTodoLists();
+                const listMap = {};
+                existingLists.forEach(l => { listMap[l.name] = l.id; });
+
+                let imported = 0;
+                for (let i = 1; i < lines.length; i++) {
+                    if (!lines[i].trim()) continue;
+                    const fields = parseCSVLine(lines[i]);
+                    const [title, listName, priority, due_date, status, notes] = fields;
+                    if (!title) continue;
+
+                    // Create list if needed
+                    let listId = listMap[listName];
+                    if (listName && !listId) {
+                        const newList = await Storage.createTodoList({ name: listName });
+                        listId = newList.id;
+                        listMap[listName] = listId;
+                    }
+
+                    const todo = await Storage.createTodo({
+                        title,
+                        list_id: listId || null,
+                        priority: priority || 'none',
+                        due_date: due_date || null,
+                        notes: notes || ''
+                    });
+
+                    if (status === 'completed') {
+                        await Storage.completeTodo(todo.id);
+                    }
+                    imported++;
+                }
+
+                alert(`Imported ${imported} todos`);
+                input.value = '';
+                loadTodos();
+                updateLocalPomodoroCount();
+            } catch (e) {
+                alert('Import failed: ' + e.message);
+                input.value = '';
+            }
+        }
+
+        // ── Plugin-Aware Type Parsing ──────────────────────────────
+
+        function parseTypeValue(value) {
+            if (value && value.startsWith('todo:')) {
+                return { type: 'To-do', linked_todo_id: value.slice(5) };
+            }
+            // Future: ticket:uuid, checklist:uuid, etc.
+            return { type: value, linked_todo_id: null };
+        }
+
         (async () => {
             await checkAuthStatus();
             await loadWeeklyOverview();
             await loadHistory();
+
+            // Load todos from cloud if logged in, then render
+            if (authStatus.logged_in) {
+                await Storage.loadTodosFromCloud();
+            }
+            await loadTodos();
         })();
     </script>
 </body>

--- a/todos_plugin.py
+++ b/todos_plugin.py
@@ -1,0 +1,76 @@
+"""Acquacotta Todos Plugin — task management with custom lists and pomodoro linking."""
+
+import json
+
+from transports.google_drive_transport import GoogleDriveTransport
+
+PLUGIN_METADATA = {
+    "id": "todos",
+    "name": "Todos",
+    "description": "Task management with custom lists and pomodoro linking",
+    "version": "1.0.0",
+    "type": "extension",
+    "author": "Crunchtools",
+}
+
+TODOS_FILE = "data.json"
+PLUGIN_FOLDER = "plugins/todos"
+
+_EMPTY_DATA = {"todos": [], "lists": []}
+
+
+def _transport(drive_service, folder_id):
+    return GoogleDriveTransport(drive_service, folder_id)
+
+
+def _ensure_plugin_folder(t, folder_id):
+    """Ensure plugins/todos/ subfolder exists, return its folder ID."""
+    service = t._service
+    # Find or create "plugins" folder
+    plugins_id = _find_or_create_folder(service, folder_id, "plugins")
+    # Find or create "todos" inside plugins
+    return _find_or_create_folder(service, plugins_id, "todos")
+
+
+def _find_or_create_folder(service, parent_id, name):
+    query = (
+        f"name='{name}' and '{parent_id}' in parents "
+        f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
+    )
+    results = service.files().list(q=query, spaces="drive", fields="files(id)").execute()
+    files = results.get("files", [])
+    if files:
+        return files[0]["id"]
+    metadata = {
+        "name": name,
+        "mimeType": "application/vnd.google-apps.folder",
+        "parents": [parent_id],
+    }
+    folder = service.files().create(body=metadata, fields="id").execute()
+    return folder["id"]
+
+
+def read_todos(drive_service, folder_id):
+    t = _transport(drive_service, folder_id)
+    todos_folder_id = _ensure_plugin_folder(t, folder_id)
+    todos_transport = GoogleDriveTransport(drive_service, todos_folder_id)
+    content = todos_transport.download_file(TODOS_FILE)
+    if content is None:
+        return dict(_EMPTY_DATA)
+    try:
+        data = json.loads(content)
+        if not isinstance(data, dict):
+            return dict(_EMPTY_DATA)
+        data.setdefault("todos", [])
+        data.setdefault("lists", [])
+        return data
+    except (json.JSONDecodeError, TypeError):
+        return dict(_EMPTY_DATA)
+
+
+def write_todos(drive_service, folder_id, data):
+    t = _transport(drive_service, folder_id)
+    todos_folder_id = _ensure_plugin_folder(t, folder_id)
+    todos_transport = GoogleDriveTransport(drive_service, todos_folder_id)
+    content = json.dumps(data, indent=2, ensure_ascii=False)
+    todos_transport.upload_file(TODOS_FILE, content)


### PR DESCRIPTION
## Summary

First extension-type plugin for Acquacotta — adds a To-do tab to the daily cockpit with full task management.

- **To-do tab**: CRUD, custom lists (Personal, Professional, Blogs, etc.), priority sorting, due dates, overdue highlighting, completed section
- **Cascading Type dropdown**: todos appear in the existing Type selector — click a list name, dropdown shows that list's todos, select one to link the pomodoro. No separate "Linked to" picker.
- **CSV import/export**: per-data-type rows in both Local Data and Remote Data cards — scales to any number of plugins
- **Drive sync**: `plugins/todos/data.json` via debounced full-replace, same transport as pomodoros
- **Plugin framework**: extension plugin toggle, activate/deactivate extension plugins, dynamic data counts
- **Click to edit**: clicking a todo row opens edit modal (like History items), checkbox toggles completion independently

### Files changed
- `todos_plugin.py` — NEW: extension plugin with Drive read/write
- `storage.js` — IndexedDB v3, todo CRUD, linked_todo_id on pomodoros
- `index.html` — To-do tab, cascading Type dropdown, dynamic Settings cards
- `plugin_registry.py` — extension plugin activate/deactivate
- `app.py` — /api/todos/sync routes, plugin registration
- `Containerfile` — include todos_plugin.py

Closes #86

## Test plan
- [ ] Import todos via CSV (demo_todos.csv or Google Tasks export)
- [ ] CRUD: create, edit, complete, delete todos
- [ ] Custom lists: create, rename, delete
- [ ] Cascading Type dropdown: click list → see todos → select one → pomodoro logs as "To-do" with link
- [ ] Drive sync: verify plugins/todos/data.json on Drive after sync
- [ ] Settings: Local Data and Remote Data cards show Pomodoros + Todos rows with counts and CSV buttons
- [ ] Plugin toggle: disable Todos plugin → tab disappears, re-enable → tab returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)