### PR TITLE
ci: Gatehouse review advisory by default (v0.4.0)

### DIFF
--- a/.github/workflows/gatehouse.yml
+++ b/.github/workflows/gatehouse.yml
@@ -32,11 +32,13 @@ jobs:
           fi
           echo "No workflow files changed."
 
+  # Advisory only — posts findings as PR comments and always passes.
+  # Do NOT mark this job a required status check (see crunchtools constitution XII).
   review:
     name: Gatehouse review
     permissions:
       contents: read
       pull-requests: write
-    uses: crunchtools/gatehouse/.github/workflows/review.yml@v0.2.0
+    uses: crunchtools/gatehouse/.github/workflows/review.yml@v0.4.0
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Bumps the Gatehouse reusable review workflow to `@v0.4.0`, which is **advisory by construction** — it exits `0` regardless of findings and posts a plain `COMMENT` review instead of `REQUEST_CHANGES`.

## Why

This repo's `Gatehouse review` check was marked a **required** status check, which let a non-deterministic LLM finding block merges (see `crunchtools/gatehouse#23`). The required-check has already been removed from branch protection; this PR aligns the workflow file:

- Pins `review.yml@v0.2.0` → `@v0.4.0` (advisory default).
- Corrects the guidance that told adopters to mark the review job required — only the `Protect workflows` guard is a blocking gate (per crunchtools constitution §XII).

No secrets or job structure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)