### PR TITLE
fix(mcp): disable FastMCP host/origin protection behind the reverse proxy

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -118,7 +118,13 @@ for registrar in plugin_registry.get_mcp_tool_registrars():
 def main():
     host = os.environ.get("MCP_HOST", "127.0.0.1")
     port = int(os.environ.get("MCP_PORT", "5001"))
-    mcp.run(transport="streamable-http", host=host, port=port)
+    # FastMCP's DNS-rebinding host/origin protection assumes a localhost-browser
+    # threat model: it rejects any Host header that isn't localhost with a 421.
+    # Acquacotta runs the server bound to 127.0.0.1 behind a trusted reverse proxy
+    # that terminates TLS and forwards the public Host, and every data operation
+    # requires a bearer token — so Apache + token auth are the real controls and
+    # this check only breaks the proxied /mcp path. Disable it.
+    mcp.run(transport="streamable-http", host=host, port=port, host_origin_protection=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Hotfix for the just-deployed MCP server. FastMCP's DNS-rebinding host/origin protection returns **421 Misdirected Request** for any non-localhost `Host` header. In production the container's Apache (`ProxyPreserveHost On`) forwards the public host `acquacotta.crunchtools.com` to uvicorn on 5001, so the proxied `/mcp` path 421'd even though the container-local path (`127.0.0.1:8080`) returned 200.

The MCP server binds `127.0.0.1` behind a trusted reverse proxy that terminates TLS and does host-based routing, and every data operation requires a bearer token — so Apache + token auth are the real controls, not a localhost-Host check. This disables `host_origin_protection`.

## Test plan
- Local: rebuilt the dev container; `POST /mcp` with `Host: acquacotta.crunchtools.com` now returns **200** (was 421).
- ruff, 200 pytest tests, and Gourmand all green.
- Post-merge: `smoke_test.sh https://acquacotta.crunchtools.com` must pass end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)