### PR TITLE
feat: live-refresh todos on out-of-band changes; persist per-list sort

### DIFF
--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -1665,6 +1665,9 @@
         _debounceTodoSync: function() {
             if (this._todoSyncTimer) clearTimeout(this._todoSyncTimer);
             if (!authStatus || !authStatus.logged_in || !isOnline) return;
+            // Mark a local change as pending so the auto-refresh poll doesn't
+            // pull remote state and clobber an edit that hasn't synced yet.
+            this._todoSyncPending = true;
             this._todoSyncTimer = setTimeout(() => this.syncTodosToCloud(), 2000);
         },
 
@@ -1677,8 +1680,68 @@
                     method: 'POST',
                     body: JSON.stringify({ todos, lists })
                 });
+                // Remote now matches what we just wrote — record the signature so the
+                // next auto-refresh poll recognizes our own change and skips a redraw.
+                this._lastTodoSignature = this._todoSignature(todos, lists);
             } catch (e) {
                 console.error('Todo sync to cloud failed:', e);
+            } finally {
+                this._todoSyncPending = false;
+            }
+        },
+
+        // Stable fingerprint of the todo document, used to detect out-of-band
+        // (e.g. MCP-made) changes without re-rendering on every poll.
+        _todoSignature: function(todos, lists) {
+            const todoRows = todos
+                .map(todo => [todo.id, todo.status, todo.title, todo.notes, todo.priority, todo.due_date, todo.list_id, todo.sort_order])
+                .sort((a, b) => (a[0] < b[0] ? -1 : 1));
+            const listRows = lists
+                .map(listing => [listing.id, listing.name, listing.order])
+                .sort((a, b) => (a[0] < b[0] ? -1 : 1));
+            return JSON.stringify([todoRows, listRows]);
+        },
+
+        // Seed the signature from local state (call once after the initial load) so
+        // the first poll only fires when something actually changed remotely.
+        seedTodoSignature: async function() {
+            const todos = await getAllFromStore(STORES.TODOS);
+            const lists = await getAllFromStore(STORES.TODO_LISTS);
+            this._lastTodoSignature = this._todoSignature(todos, lists);
+        },
+
+        // Pull the todo document from the cloud and reconcile IndexedDB to match it
+        // exactly (adds, updates, AND deletes) when it differs from what we last saw.
+        // Returns true if local state changed, so the caller can re-render.
+        refreshTodosFromCloudIfChanged: async function() {
+            if (!authStatus || !authStatus.logged_in || !isOnline) return false;
+            if (this._todoSyncPending) return false;  // don't stomp an unsynced local edit
+            try {
+                const res = await authenticatedFetch('/api/todos/sync');
+                if (!res.ok) return false;
+                const payload = await res.json();
+                const remoteTodos = payload.todos || [];
+                const remoteLists = payload.lists || [];
+                const sig = this._todoSignature(remoteTodos, remoteLists);
+                if (sig === this._lastTodoSignature) return false;
+
+                const localTodos = await getAllFromStore(STORES.TODOS);
+                const localLists = await getAllFromStore(STORES.TODO_LISTS);
+                const remoteTodoIds = new Set(remoteTodos.map(t => t.id));
+                const remoteListIds = new Set(remoteLists.map(l => l.id));
+                for (const t of localTodos) {
+                    if (!remoteTodoIds.has(t.id)) await deleteFromStore(STORES.TODOS, t.id);
+                }
+                for (const l of localLists) {
+                    if (!remoteListIds.has(l.id)) await deleteFromStore(STORES.TODO_LISTS, l.id);
+                }
+                for (const t of remoteTodos) await putInStore(STORES.TODOS, t);
+                for (const l of remoteLists) await putInStore(STORES.TODO_LISTS, l);
+                this._lastTodoSignature = sig;
+                return true;
+            } catch (e) {
+                console.error('Todo refresh check failed:', e);
+                return false;
             }
         },
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5361,6 +5361,8 @@
             if (!document.hidden) {
                 // Tab became visible - trigger clock update to check for date change
                 updateClock();
+                // Pick up out-of-band (MCP) todo changes immediately on refocus
+                refreshTodosIfChanged();
             }
         });
 
@@ -5591,6 +5593,10 @@
         let todoSelectedListId = 'all';
         let todoCompletedVisible = false;
         let todoSortOrder = 'manual';
+        // Per-list sort preferences ({ listId|'all': sortMode }), persisted in the
+        // settings store and synced to the active backend. todoSortOrder mirrors the
+        // entry for the currently selected list.
+        let todoSortOrders = {};
 
         function escTodo(s) { return escapeHtml(s); }
 
@@ -5608,6 +5614,10 @@
             const bar = document.getElementById('todo-lists-bar');
             bar.innerHTML = `<button class="${todoSelectedListId === 'all' ? 'active' : ''}" onclick="selectTodoList('all')">All</button>` +
                 lists.map(l => `<button class="${todoSelectedListId === l.id ? 'active' : ''}" onclick="selectTodoList('${l.id}')">${escTodo(l.name)}</button>`).join('');
+
+            // Keep the sort dropdown in sync with this list's saved preference
+            const sortSelect = document.getElementById('todo-sort');
+            if (sortSelect) sortSelect.value = todoSortOrder;
 
             // Filter by selected list
             const filtered = todoSelectedListId === 'all' ? todos : todos.filter(t => t.list_id === todoSelectedListId);
@@ -5720,6 +5730,7 @@
 
         function selectTodoList(listId) {
             todoSelectedListId = listId;
+            todoSortOrder = todoSortOrders[listId] || 'manual';
             loadTodos();
         }
 
@@ -5741,7 +5752,26 @@
 
         function setTodoSort(value) {
             todoSortOrder = value;
+            todoSortOrders[todoSelectedListId] = value;
+            // Persists to IndexedDB and syncs to the active backend (JSON/Sheets).
+            Storage.saveSetting('todo_sort_orders', todoSortOrders);
             loadTodos();
+        }
+
+        let _todoRefreshTimer = null;
+        // Poll for out-of-band todo changes (e.g. made via the MCP server) and
+        // reconcile IndexedDB, re-rendering only when the todos view is visible.
+        async function refreshTodosIfChanged() {
+            if (document.hidden) return;
+            if (!authStatus || !authStatus.logged_in) return;
+            const changed = await Storage.refreshTodosFromCloudIfChanged();
+            if (changed && document.getElementById('todos-view').classList.contains('active')) {
+                await loadTodos();
+            }
+        }
+        function startTodoAutoRefresh() {
+            if (_todoRefreshTimer) return;
+            _todoRefreshTimer = setInterval(refreshTodosIfChanged, 30000);
         }
 
         // ── Todo drag-to-reorder (manual sort) ───────────────────
@@ -6058,7 +6088,18 @@
             if (authStatus.logged_in) {
                 await Storage.loadTodosFromCloud();
             }
+            // Restore per-list sort preferences (persisted in settings, synced to backend)
+            try {
+                const _settings = await Storage.getSettings();
+                todoSortOrders = _settings.todo_sort_orders || {};
+                todoSortOrder = todoSortOrders[todoSelectedListId] || 'manual';
+            } catch (e) { /* fall back to defaults */ }
             await loadTodos();
+            // Start auto-refresh so out-of-band (MCP) todo changes appear without a manual reload
+            if (authStatus.logged_in) {
+                await Storage.seedTodoSignature();
+                startTodoAutoRefresh();
+            }
         })();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- **Auto-refresh** — the browser now polls `/api/todos/sync` every 30s and on tab refocus, reconciles IndexedDB to match remote (adds/updates/**deletes**), and re-renders when the todos view is visible. Todo changes made via the **MCP server** appear without a manual browser reload. A per-write signature + pending-sync guard prevent redraw loops and protect unsynced local edits.
- **Per-list sort** — sort order is saved per list (by list id) in the settings store, so it survives a browser refresh and syncs to the active backend (JSON/Sheets) across devices, replacing the single volatile global.

## Scope
Vanilla JS only — `static/js/storage.js` + `templates/index.html`. No backend/API or schema changes.

## Test plan
- [x] Gourmand clean, storage.js `node --check` passes
- [ ] Per-list sort persists across F5 and differs per list
- [ ] MCP-made todo add/delete auto-appears within ~30s / on refocus

🤖 Generated with [Claude Code](https://claude.com/claude-code)