### PR TITLE
feat: per-user storage backend selection + robust login (spec 007)

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,7 +61,11 @@ MCP_PLUGIN_METADATA = {
     "has_mcp": True,
 }
 plugin_registry.register("integration", "mcp", SimpleNamespace(), MCP_PLUGIN_METADATA)
-plugin_registry.activate_storage("sheets")
+# Default backend for users with no recorded choice (post-migration standard).
+DEFAULT_STORAGE_BACKEND = "json-google-drive"
+# The active backend is resolved per-user (see _active_storage_id); this only sets a
+# harmless registry default for the no-user case, matching DEFAULT_STORAGE_BACKEND.
+plugin_registry.activate_storage(DEFAULT_STORAGE_BACKEND)
 
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_port=1)
@@ -174,8 +178,15 @@ OAUTH_STATE_MAX_AGE_SECONDS = 600
 DEFAULT_PORT = 5000
 
 
+# Per-user storage preference file. Holds ONLY routing metadata (each user's chosen
+# backend + the location pointer for each backend) — never user content or PII beyond
+# the account email used as the key. Shape:
+#   {email: {"backend": "<id>", "sheets": "<spreadsheet_id>", "json-google-drive": "<folder_id>"}}
+_BACKEND_KEY = "backend"
+
+
 def _user_mapping_path():
-    """Get path to the user-to-storage-location mapping file."""
+    """Path to the per-user storage-preference file (migrates the legacy name)."""
     new_path = DATA_DIR / "user_storage.json"
     if not new_path.exists():
         legacy_path = DATA_DIR / "user_spreadsheets.json"
@@ -184,39 +195,56 @@ def _user_mapping_path():
     return new_path
 
 
-def get_stored_location(email, plugin_id):
-    """Get stored storage location for a user+plugin combination."""
-    mapping_path = _user_mapping_path()
-    if mapping_path.exists():
+def _read_user_mapping():
+    path = _user_mapping_path()
+    if path.exists():
         try:
-            with open(mapping_path) as f:
-                mapping = json.load(f)
+            with open(path) as f:
+                return json.load(f)
         except (json.JSONDecodeError, OSError):
-            return None
-        user_entry = mapping.get(email, {})
-        if isinstance(user_entry, str):
-            return user_entry if plugin_id == "sheets" else None
-        return user_entry.get(plugin_id)
-    return None
+            return {}
+    return {}
+
+
+def _write_user_mapping(mapping):
+    with open(_user_mapping_path(), "w") as f:
+        json.dump(mapping, f)
+
+
+def _user_entry(mapping, email):
+    """The per-user dict, upgrading the legacy bare-spreadsheet-id form."""
+    entry = mapping.get(email, {})
+    if isinstance(entry, str):  # legacy value was always a Sheets spreadsheet id
+        return {"sheets": entry}
+    return entry
+
+
+def get_stored_location(email, plugin_id):
+    """Get the stored location id for a user's given backend, or None."""
+    return _user_entry(_read_user_mapping(), email).get(plugin_id)
 
 
 def save_location(email, plugin_id, location_id):
-    """Save storage location for a user+plugin combination."""
-    mapping_path = _user_mapping_path()
-    mapping = {}
-    if mapping_path.exists():
-        try:
-            with open(mapping_path) as f:
-                mapping = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            mapping = {}
-    user_entry = mapping.get(email, {})
-    if isinstance(user_entry, str):
-        user_entry = {"sheets": user_entry}
-    user_entry[plugin_id] = location_id
-    mapping[email] = user_entry
-    with open(mapping_path, "w") as f:
-        json.dump(mapping, f)
+    """Persist a user's location id for a backend."""
+    mapping = _read_user_mapping()
+    entry = _user_entry(mapping, email)
+    entry[plugin_id] = location_id
+    mapping[email] = entry
+    _write_user_mapping(mapping)
+
+
+def get_user_backend(email):
+    """Return the user's authoritative chosen storage backend id, or None if unset."""
+    return _user_entry(_read_user_mapping(), email).get(_BACKEND_KEY)
+
+
+def set_user_backend(email, plugin_id):
+    """Persist the user's authoritative storage-backend choice."""
+    mapping = _read_user_mapping()
+    entry = _user_entry(mapping, email)
+    entry[_BACKEND_KEY] = plugin_id
+    mapping[email] = entry
+    _write_user_mapping(mapping)
 
 
 def get_google_flow():
@@ -328,9 +356,38 @@ def get_drive_service():
     return build("drive", "v3", credentials=credentials)
 
 
+def _request_user_email():
+    """Email of the user making the current request — from the OAuth session (during
+    the callback) or the credentials the client sends (stateless API requests)."""
+    if session.get("user_email"):
+        return session["user_email"]
+    creds = get_credentials_from_request()
+    return creds.get("user_email") if creds else None
+
+
+def _active_storage_id():
+    """The storage backend for THIS request's user: their authoritative recorded
+    choice, never a shared global. Users with no recorded choice get the default."""
+    email = _request_user_email()
+    if email:
+        backend = get_user_backend(email)
+        if backend:
+            return backend
+    return DEFAULT_STORAGE_BACKEND
+
+
+def _active_storage_backend():
+    """The storage backend module for this request's user, or None if unregistered."""
+    return plugin_registry.get_plugin("storage", _active_storage_id())
+
+
 def _storage_context():
-    """Build storage context for the active backend, or None if no backend is active."""
-    backend = plugin_registry.get_active_storage()
+    """Build storage context for the requesting user's backend, or None.
+
+    The resolved per-user backend is carried in the context so the data layer
+    dispatches to THIS user's backend — never a shared global.
+    """
+    backend = _active_storage_backend()
     if backend is None:
         return None
     credentials = get_credentials()
@@ -339,7 +396,9 @@ def _storage_context():
     request_creds = get_credentials_from_request()
     if not request_creds:
         return None
-    return backend.build_context(credentials, request_creds)
+    ctx = backend.build_context(credentials, request_creds)
+    ctx["backend"] = backend
+    return ctx
 
 
 def is_logged_in():
@@ -347,7 +406,7 @@ def is_logged_in():
     creds = get_credentials_from_request()
     if not creds or not creds.get("token"):
         return False
-    backend = plugin_registry.get_active_storage()
+    backend = _active_storage_backend()
     if backend is None:
         return True
     metadata = getattr(backend, "PLUGIN_METADATA", {})
@@ -399,13 +458,18 @@ def auth_google():
         # Bundle PKCE code_verifier + CSRF nonce into a signed state parameter.
         # Google echoes `state` back in the callback URL, so it survives the redirect
         # chain regardless of cookie behavior. No session/cookie dependency for PKCE.
-        requested_spreadsheet_id = request.args.get("spreadsheet_id", "").strip()
+        # The client sends the location id under the field matching its backend —
+        # spreadsheet_id for Sheets, folder_id for JSON-on-Drive — never conflated.
         state_payload = {
             "s": state,  # Original CSRF nonce
             "cv": flow.code_verifier,  # PKCE code_verifier
         }
+        requested_spreadsheet_id = request.args.get("spreadsheet_id", "").strip()
+        requested_folder_id = request.args.get("folder_id", "").strip()
         if requested_spreadsheet_id:
             state_payload["sid"] = requested_spreadsheet_id
+        if requested_folder_id:
+            state_payload["fid"] = requested_folder_id
 
         s = URLSafeTimedSerializer(app.config["SECRET_KEY"])
         signed_state = s.dumps(state_payload)
@@ -547,6 +611,7 @@ def auth_callback():
 
         code_verifier = state_data["cv"]
         requested_spreadsheet_id = state_data.get("sid")
+        requested_folder_id = state_data.get("fid")
 
         flow = get_google_flow()
         if not flow:
@@ -595,11 +660,17 @@ def auth_callback():
         session["user_name"] = user_info.get("name")
         session["user_picture"] = user_info.get("picture")
 
-        # Determine which storage plugin is active and provision accordingly
-        active_storage_id = plugin_registry.get_active_storage_id()
-        location_id, location_existed = _provision_storage(
-            active_storage_id, credentials, user_email, requested_spreadsheet_id
+        # Resolve THIS user's backend (their recorded choice, or the default for a
+        # first-time user) and provision it with the id matching that backend.
+        active_storage_id = _active_storage_id()
+        requested_location_id = (
+            requested_folder_id if active_storage_id == "json-google-drive" else requested_spreadsheet_id
         )
+        location_id, location_existed = _provision_storage(
+            active_storage_id, credentials, user_email, requested_location_id
+        )
+        # Record the backend as this user's authoritative choice (survives sign-out).
+        set_user_backend(user_email, active_storage_id)
 
         # Build credentials data for frontend storage (AUTH store - ephemeral)
         credentials_data = {
@@ -616,7 +687,7 @@ def auth_callback():
 
         # Settings data (SETTINGS store - persistent)
         # Write the plugin's frontend_fields so the browser sends them with API requests
-        backend = plugin_registry.get_active_storage()
+        backend = _active_storage_backend()
         metadata = getattr(backend, "PLUGIN_METADATA", {})
         frontend_fields = metadata.get("frontend_fields", [])
 
@@ -627,81 +698,27 @@ def auth_callback():
         # Clear server session - credentials will live in browser IndexedDB
         session.clear()
 
-        # Build the JS that writes plugin-specific settings to IndexedDB
-        settings_js_lines = []
-        for field in frontend_fields:
-            settings_js_lines.append(
-                f"        settingsStore.put({{ key: '{field}', value: settings.{field}, synced: true }});"
-            )
-        settings_js_lines.append(
-            "        settingsStore.put({ key: 'storage_existed', value: settings.storage_existed, synced: true });"
-        )
-        settings_js = "\n".join(settings_js_lines)
-
-        # Return HTML page that stores credentials in IndexedDB then redirects
-        # Note: DB_VERSION must match storage.js (currently 2)
+        # Hand the login off to storage.js via sessionStorage, then redirect.
+        #
+        # The callback deliberately does NOT open IndexedDB itself. storage.js is
+        # the single owner of the IndexedDB schema (store list + DB version); it
+        # picks up this pending login on load and writes it with the correct
+        # version. This removes the duplicated schema that previously let the
+        # callback's stale DB version throw VersionError and silently drop
+        # credentials, leaving the user logged out after a "successful" login.
+        pending_auth = {"credentials": credentials_data, "settings": settings_data}
         return f"""<!DOCTYPE html>
 <html>
 <head><title>Logging in...</title></head>
 <body>
 <p>Completing login...</p>
 <script>
-const credentials = {json.dumps(credentials_data)};
-const settings = {json.dumps(settings_data)};
-const DB_VERSION = 2;  // Must match storage.js
-
-// Store in IndexedDB
-const dbRequest = indexedDB.open('acquacotta', DB_VERSION);
-dbRequest.onupgradeneeded = (e) => {{
-    const db = e.target.result;
-    // Create all stores that storage.js expects
-    if (!db.objectStoreNames.contains('pomodoros')) {{
-        const pomodorosStore = db.createObjectStore('pomodoros', {{ keyPath: 'id' }});
-        pomodorosStore.createIndex('start_time', 'start_time', {{ unique: false }});
-        pomodorosStore.createIndex('type', 'type', {{ unique: false }});
-        pomodorosStore.createIndex('synced', 'synced', {{ unique: false }});
-    }}
-    if (!db.objectStoreNames.contains('settings')) {{
-        db.createObjectStore('settings', {{ keyPath: 'key' }});
-    }}
-    if (!db.objectStoreNames.contains('sync_queue')) {{
-        const syncStore = db.createObjectStore('sync_queue', {{ keyPath: 'id', autoIncrement: true }});
-        syncStore.createIndex('created_at', 'created_at', {{ unique: false }});
-    }}
-    if (!db.objectStoreNames.contains('sync_status')) {{
-        db.createObjectStore('sync_status', {{ keyPath: 'key' }});
-    }}
-    if (!db.objectStoreNames.contains('auth')) {{
-        db.createObjectStore('auth', {{ keyPath: 'key' }});
-    }}
-}};
-dbRequest.onsuccess = (e) => {{
-    const db = e.target.result;
-    // Store auth credentials (ephemeral)
-    const authTx = db.transaction('auth', 'readwrite');
-    authTx.objectStore('auth').put({{ key: 'credentials', ...credentials }});
-    authTx.oncomplete = () => {{
-        // Store plugin-specific settings (persistent)
-        const settingsTx = db.transaction('settings', 'readwrite');
-        const settingsStore = settingsTx.objectStore('settings');
-{settings_js}
-        settingsTx.oncomplete = () => {{
-            window.location.href = '/?view=settings';
-        }};
-        settingsTx.onerror = (err) => {{
-            console.error('Settings transaction error:', err);
-            window.location.href = '/?view=settings';
-        }};
-    }};
-    authTx.onerror = (err) => {{
-        console.error('Auth transaction error:', err);
-        window.location.href = '/?view=settings';
-    }};
-}};
-dbRequest.onerror = (e) => {{
-    console.error('Failed to open IndexedDB:', e.target.error);
-    window.location.href = '/?view=settings';
-}};
+try {{
+    sessionStorage.setItem('acquacotta_pending_auth', JSON.stringify({json.dumps(pending_auth)}));
+}} catch (e) {{
+    console.error('Failed to stash pending auth:', e);
+}}
+window.location.href = '/?view=settings';
 </script>
 </body>
 </html>"""
@@ -797,7 +814,7 @@ def api_provision_storage():
     if not user_email:
         return jsonify({"error": "No user email in credentials"}), HTTPStatus.BAD_REQUEST
 
-    active_id = plugin_registry.get_active_storage_id()
+    active_id = _active_storage_id()
     if not active_id:
         return jsonify({"error": "No storage plugin active"}), HTTPStatus.BAD_REQUEST
 
@@ -807,7 +824,7 @@ def api_provision_storage():
         app.logger.error(f"Storage provisioning failed: {e}")
         return jsonify({"error": f"Provisioning failed: {e}"}), HTTPStatus.INTERNAL_SERVER_ERROR
 
-    backend = plugin_registry.get_active_storage()
+    backend = _active_storage_backend()
     metadata = getattr(backend, "PLUGIN_METADATA", {})
     frontend_fields = metadata.get("frontend_fields", [])
 
@@ -840,7 +857,7 @@ def api_migrate_to_json():
         msg = "Not authenticated" if not credentials else "No user email in credentials"
         return jsonify({"error": msg}), status
 
-    if plugin_registry.get_active_storage_id() != "sheets":
+    if _active_storage_id() != "sheets":
         return jsonify({"error": "Migration is only available when using the Sheets backend"}), HTTPStatus.BAD_REQUEST
 
     try:
@@ -864,9 +881,9 @@ def api_migrate_to_json():
         app.logger.error(f"Migration failed: {e}")
         return jsonify({"error": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
 
-    # Step 4: Switch backend (only after successful write)
+    # Step 4: Switch this user's backend (only after successful write)
     save_location(user_email, "json-google-drive", folder_id)
-    plugin_registry.activate_storage("json-google-drive")
+    set_user_backend(user_email, "json-google-drive")
 
     return jsonify(
         {
@@ -884,12 +901,21 @@ def api_migrate_to_json():
 
 @app.route("/api/plugins")
 def api_list_plugins():
-    """List all registered plugins with their status."""
+    """List all registered plugins with their status.
+
+    Storage `active` is resolved per-request from the requesting user's own recorded
+    backend choice, never a shared global.
+    """
+    active_storage = _active_storage_id()
+    plugins = plugin_registry.list_plugins()
+    for plugin in plugins:
+        if plugin.get("plugin_type") == "storage":
+            plugin["active"] = plugin.get("id") == active_storage
     return jsonify(
         {
-            "plugins": plugin_registry.list_plugins(),
+            "plugins": plugins,
             "types": plugin_registry.list_plugin_types(),
-            "active_storage": plugin_registry.get_active_storage_id(),
+            "active_storage": active_storage,
         }
     )
 
@@ -906,13 +932,15 @@ def api_toggle_plugin():
     enable = toggle_request.get("enable", True)
 
     if plugin_type == "storage":
+        # A storage backend is a per-user authoritative choice, not a global toggle:
+        # enabling one records it as this user's backend (they switch by enabling another).
+        email = _request_user_email()
+        if not email:
+            return jsonify({"error": "Not authenticated"}), HTTPStatus.UNAUTHORIZED
         if enable:
-            try:
-                plugin_registry.activate_storage(plugin_id)
-            except ValueError as e:
-                return jsonify({"error": str(e)}), HTTPStatus.BAD_REQUEST
-        else:
-            plugin_registry.deactivate_storage()
+            if plugin_registry.get_plugin("storage", plugin_id) is None:
+                return jsonify({"error": f"Storage plugin not registered: {plugin_id}"}), HTTPStatus.BAD_REQUEST
+            set_user_backend(email, plugin_id)
     elif plugin_type == "extension":
         try:
             if enable:
@@ -927,7 +955,7 @@ def api_toggle_plugin():
     return jsonify(
         {
             "status": "ok",
-            "active_storage": plugin_registry.get_active_storage_id(),
+            "active_storage": _active_storage_id(),
         }
     )
 

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -56,6 +56,16 @@ check = "summary_litter"
 path = "specs/001-slidable-timer/checklists/requirements.md"
 justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
 
+[[exceptions]]
+check = "summary_litter"
+path = "specs/007-per-user-storage/spec.md"
+justification = "Spec-kit feature specification - RFC/ADR-style development workflow"
+
+[[exceptions]]
+check = "summary_litter"
+path = "specs/007-per-user-storage/checklists/requirements.md"
+justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # random_scripts - Intentional entry points
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/specs/007-per-user-storage/checklists/requirements.md
+++ b/specs/007-per-user-storage/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Per-User Storage Backend Selection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The design approach (per-user server-side pointer record, per-request resolution, correct id naming) is intentionally kept out of the spec's mandatory sections and belongs in `/speckit.plan`. It is summarized only in Assumptions to justify the "server MAY hold a routing pointer" decision, which was an explicit stakeholder clarification.
+- No items require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/007-per-user-storage/spec.md
+++ b/specs/007-per-user-storage/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Per-User Storage Backend Selection
+
+**Feature Branch**: `007-per-user-storage`
+**Created**: 2026-07-11
+**Status**: Draft
+**Input**: User description: "Per-user storage backend selection: authoritative per-user backend choice, no global race, correct folder-vs-spreadsheet id handling"
+
+## Overview
+
+Each Acquacotta user syncs their data to one of two storage backends in their own Google account: **Google Sheets** (a spreadsheet) or **JSON-on-Google-Drive** (a folder). Today the app tracks which backend is "active" as a single **process-wide** value rather than a per-user choice. As a result a user's backend selection is not reliably remembered, is contaminated by other activity, and their two location identifiers (a Drive **folder id** and a Sheets **spreadsheet id**) get crossed. The observable effect is that a user signs in and the app silently uses the *wrong* backend, so their data never loads.
+
+This feature makes each user's storage-backend choice **authoritative, per-user, and durable across sign-out**, and makes the two location identifiers unambiguous end-to-end, so login and sync are deterministic for every user.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Returning user's backend and data load reliably (Priority: P1)
+
+A user who has previously chosen a storage backend signs out and signs back in (possibly on a new device, after clearing their browser, or after the service restarts). The app resolves *their* backend and *their* data location, and their data loads — every time, without the user having to re-select anything or paste an id.
+
+**Why this priority**: This is the core failure today — a JSON user is silently resolved to Sheets on re-login and their data never appears. Without this, the app is unusable across sign-out for anyone who isn't on the process-wide default backend.
+
+**Independent Test**: With a user whose recorded backend is JSON-on-Drive, sign out completely and sign back in; confirm the app resolves to JSON, opens their existing folder, and loads their pomodoros and todos — with no dependence on prior browser state or which user last used the service.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user whose recorded choice is JSON-on-Drive, **When** they sign out and sign back in, **Then** the app resolves to JSON, uses their existing folder, and their data loads.
+2. **Given** a user whose recorded choice is Sheets, **When** they sign out and sign back in, **Then** the app resolves to Sheets, uses their existing spreadsheet, and their data loads.
+3. **Given** the service has just restarted (no in-memory state), **When** any returning user signs in, **Then** their backend is resolved from their durable choice, not from a default.
+
+---
+
+### User Story 2 - Concurrent users never affect each other's backend (Priority: P1)
+
+Two users are active at the same time on different backends (one on Sheets, one on JSON). Each user's requests always use *their own* backend; neither user's activity changes the backend the other user gets.
+
+**Why this priority**: The app is a hosted multi-user service. A shared process-wide "active backend" means one user's session can flip another user onto the wrong backend (last-writer-wins), corrupting where data is read/written. Per-user isolation is a correctness and data-safety requirement.
+
+**Independent Test**: Drive requests for two users with different recorded backends interleaved; confirm each user's operations consistently target their own backend and location regardless of the other's activity or ordering.
+
+**Acceptance Scenarios**:
+
+1. **Given** User A on Sheets and User B on JSON acting concurrently, **When** their requests interleave, **Then** A's operations always target Sheets and B's always target JSON.
+2. **Given** User A changes their backend, **When** User B makes a request, **Then** User B's resolved backend is unchanged.
+
+---
+
+### User Story 3 - The login form uses the correct location field per backend (Priority: P2)
+
+At sign-in, the user is offered the location field appropriate to their backend — a **Drive Folder ID** for JSON, a **Spreadsheet ID** for Sheets — and the value they enter (or that is remembered) is always transmitted and interpreted as that kind of id, never crossed.
+
+**Why this priority**: Folder ids and spreadsheet ids are both opaque Google ids and are currently conflated (the app stored a single "spreadsheet id" and sent it for both backends). A folder id sent as a spreadsheet id makes provisioning fail. This must be correct for JSON users to sign in at all with an explicit id.
+
+**Independent Test**: On a JSON account, confirm the sign-in form shows a "Drive Folder ID" field, an entered folder id is accepted and used as a folder, and it is never treated as a spreadsheet id; repeat symmetrically for Sheets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user whose backend is JSON, **When** the sign-in form is shown, **Then** it offers a Drive Folder ID field and an entered id is used as a folder id.
+2. **Given** a user whose backend is Sheets, **When** the sign-in form is shown, **Then** it offers a Spreadsheet ID field and an entered id is used as a spreadsheet id.
+3. **Given** either backend, **When** the location field is left blank, **Then** the user's existing location is found automatically (by their recorded choice or by discovery) without creating a duplicate.
+
+---
+
+### User Story 4 - Switching backend is an explicit, durable per-user choice (Priority: P3)
+
+A user deliberately switches their storage backend. That choice is recorded as theirs and is honored on every subsequent request and future sign-in, until they change it again.
+
+**Why this priority**: Backend selection should be a conscious, remembered decision — not something inferred from stale client state or flipped implicitly on page load. This removes the implicit client-driven "toggle" behavior that caused drift.
+
+**Independent Test**: As a user, switch backend, sign out and back in, and confirm the newly chosen backend is the one used; confirm no page-load side effect silently changes it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user switches to a different backend, **When** they sign out and back in, **Then** the newly chosen backend is used.
+2. **Given** a signed-in session, **When** the page loads, **Then** the user's recorded backend is used as-is and is not implicitly changed by the client.
+
+---
+
+### Edge Cases
+
+- **Data in both backends**: A user who has an old spreadsheet *and* a JSON folder is resolved to their **recorded choice**, deterministically — never guessed from which ids happen to be cached.
+- **No recorded choice (new or first-time user)**: Resolves to a single, well-defined default backend, and the user can switch; provisioning finds-or-creates their location without duplicating it.
+- **Missing/corrupt preference record**: The system fails safe — it does not silently read or write to the wrong backend; the user is guided to (re)select rather than losing or splitting data.
+- **Wrong-kind id entered**: A value entered in the folder field is only ever used as a folder id (and vice versa); it is never reinterpreted as the other kind.
+- **Stale client state after sign-out**: Leftover ids or flags in the browser do not override the user's recorded backend choice.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST record each user's chosen storage backend as a per-user value that is durable across sign-out, sign-in, and service restarts.
+- **FR-002**: The system MUST resolve the active storage backend for any operation from the *requesting user's* recorded choice, never from a value shared across users.
+- **FR-003**: One user's backend choice or activity MUST NOT change the backend resolved for any other user.
+- **FR-004**: At sign-in, the system MUST provision and open the user's recorded backend and location deterministically, without requiring the user to re-select or re-enter their location.
+- **FR-005**: The system MUST store and transmit the JSON location (**folder id**) and the Sheets location (**spreadsheet id**) as distinct, correctly-named values, and MUST NOT use one where the other is expected.
+- **FR-006**: The sign-in experience MUST present the location field appropriate to the user's backend and, when a value is provided, use it as that kind of id.
+- **FR-007**: When the user provides no location, the system MUST locate the user's existing storage (by recorded choice or by discovery) without creating a duplicate spreadsheet or folder.
+- **FR-008**: When a user switches backend, the system MUST persist that as the user's authoritative choice and honor it on all subsequent operations and future sign-ins.
+- **FR-009**: The system MUST NOT implicitly change a user's backend as a side effect of page load or restored client state.
+- **FR-010**: On a missing, ambiguous, or unreadable preference, the system MUST fail safe (not read/write the wrong backend) and prompt the user to confirm their backend rather than silently defaulting in a way that splits their data.
+- **FR-011**: The per-user preference record MUST contain only backend selection and location pointers — no pomodoro, todo, settings content, or other user data/PII beyond the account identifier already required to key it.
+- **FR-012**: User content (pomodoros, todos, settings) MUST continue to live only in the user's own Google storage and browser cache; this feature adds no user content to the server.
+
+### Key Entities
+
+- **User Storage Preference**: The per-user record of where and how a user syncs. Attributes: the user's account identifier (key), the chosen backend (Sheets or JSON-on-Drive), and the location pointer for that backend (spreadsheet id or folder id). It is a *pointer*, not user content.
+- **Storage Backend**: A supported sync target — "Google Sheets" (identified by a spreadsheet id) or "JSON on Google Drive" (identified by a folder id). Exactly one is active per user at a time.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of returning users (on either backend) are resolved to their own backend and location on sign-in, including after a service restart and with no reliance on prior browser state.
+- **SC-002**: 0 instances of a user's backend being determined by another user's activity under concurrent use.
+- **SC-003**: 0 instances of a folder id being used as a spreadsheet id (or vice versa) across sign-in and sync.
+- **SC-004**: A user who switches backend and signs out/in gets the newly chosen backend 100% of the time.
+- **SC-005**: A user with no location entered has their existing storage found without any duplicate spreadsheet or folder being created.
+- **SC-006**: The server stores no user content — only the per-user backend/location pointer — verifiable by inspecting what the server persists.
+
+## Assumptions
+
+- A small per-user server-side record mapping account identifier → {backend, location pointer} is acceptable; the constitution's constraint is against storing user **PII/content** on the server, not against a minimal routing pointer. User data itself remains solely in the user's Google storage and browser cache.
+- Both backends remain supported; some users are still on Sheets, so this is not a Sheets-removal.
+- The default backend for brand-new users is JSON-on-Google-Drive (the current standard post-migration), and new users may switch to Sheets.
+- The account identifier used to key the preference is the user's Google account email, already obtained during OAuth.
+
+## Out of Scope
+
+- Removing or deprecating the Google Sheets backend.
+- Migrating existing users' data between backends (this feature preserves each user's current backend and data in place).
+- Changes to how MCP token access resolves storage (MCP tokens already carry their own folder pointer).

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -18,6 +18,9 @@
     const DB_NAME = 'acquacotta';
     const DB_VERSION = 3;  // Bumped for todos stores
 
+    // sessionStorage handoff key the OAuth callback writes a pending login to
+    const PENDING_AUTH_KEY = 'acquacotta_pending_auth';
+
     // Object store names
     const STORES = {
         POMODOROS: 'pomodoros',
@@ -84,6 +87,7 @@
     let syncLockPromise = null;  // Promise-based lock to prevent race conditions
     let pendingSyncCount = 0;
     let lastSyncError = null;
+    let initialSyncPromise = null;  // Background bidirectional sync started at login
 
     /**
      * Generate a UUID v4
@@ -251,6 +255,44 @@
             console.error('Error loading credentials:', e);
         }
         return null;
+    }
+
+    /**
+     * Consume a pending login handed off by the OAuth callback via sessionStorage.
+     *
+     * The callback used to write IndexedDB itself, duplicating the schema (store
+     * list + DB version). When storage.js bumped the DB version, the callback's
+     * lower hard-coded version threw VersionError and credentials were silently
+     * dropped — login "succeeded" but the browser stayed logged out. To make
+     * that impossible, the callback now only stashes {credentials, settings} in
+     * sessionStorage; storage.js — the single owner of the IndexedDB schema —
+     * writes them here using its own openDatabase(). One source of truth.
+     */
+    async function consumePendingAuth() {
+        let pending;
+        try {
+            const raw = sessionStorage.getItem(PENDING_AUTH_KEY);
+            if (!raw) return;
+            pending = JSON.parse(raw);
+        } catch (e) {
+            console.error('Error reading pending auth:', e);
+            return;
+        }
+        try {
+            if (pending.credentials) {
+                await putInStore(STORES.AUTH, { key: 'credentials', ...pending.credentials });
+            }
+            if (pending.settings) {
+                for (const [key, value] of Object.entries(pending.settings)) {
+                    await putInStore(STORES.SETTINGS, { key, value, synced: true });
+                }
+            }
+        } catch (e) {
+            console.error('Error persisting pending auth:', e);
+            return;
+        }
+        // Only clear once safely written, so a mid-write failure can retry next load.
+        try { sessionStorage.removeItem(PENDING_AUTH_KEY); } catch (e) { /* ignore */ }
     }
 
     /**
@@ -672,6 +714,9 @@
             // Open IndexedDB first (idempotent if already opened)
             await openDatabase();
 
+            // Persist any login the OAuth callback just handed off (single schema owner)
+            await consumePendingAuth();
+
             // Load credentials from AUTH store (ephemeral - OAuth tokens only)
             const creds = await loadCredentials();
 
@@ -800,9 +845,17 @@
             // Update pending count
             await updatePendingCount();
 
-            // Bidirectional sync on every page load when logged in
+            // Bidirectional sync on every page load when logged in.
+            // Runs in the BACKGROUND (not awaited) so init() returns immediately and
+            // the logged-in UI renders instantly. It flips syncInProgress and emits
+            // sync-status events, so the header shows "Syncing…" then "Synced" and the
+            // data counts fill in when it completes. Callers can await
+            // Storage.whenInitialSyncDone() if they need the merged data.
             if (authStatus.logged_in && storedCredentials) {
-                try {
+                initialSyncPromise = (async () => {
+                    syncInProgress = true;
+                    dispatchSyncStatusEvent();
+                    try {
                     // Clear any stale sync queue — the batch push below handles everything
                     await clearStore(STORES.SYNC_QUEUE);
 
@@ -876,10 +929,24 @@
 
                     // Mark storage as existing
                     await putInStore(STORES.SETTINGS, { key: 'storage_existed', value: true, synced: true });
-                } catch (e) {
-                    console.error('Bidirectional sync during init failed:', e);
-                }
+                    } catch (e) {
+                        console.error('Bidirectional sync during init failed:', e);
+                    } finally {
+                        syncInProgress = false;
+                        await updatePendingCount();  // dispatches sync-status → UI flips to "Synced"
+                    }
+                })();
             }
+        },
+
+        /**
+         * Resolve when the background bidirectional sync started at login has
+         * finished (or immediately if none is running). Lets callers refresh
+         * counts/render once the merged data is available.
+         * @returns {Promise}
+         */
+        whenInitialSyncDone: function() {
+            return initialSyncPromise || Promise.resolve();
         },
 
         /**
@@ -929,15 +996,26 @@
          * @returns {Promise<string|null>}
          */
         getStoredSpreadsheetId: async function() {
+            return this.getStoredLocationId('spreadsheet_id');
+        },
+
+        /**
+         * Get a stored location id (spreadsheet_id or folder_id) from settings,
+         * for auto-fill on login. Folder ids and spreadsheet ids are kept
+         * distinct and are never conflated.
+         * @param {string} field - 'spreadsheet_id' or 'folder_id'
+         * @returns {Promise<string|null>}
+         */
+        getStoredLocationId: async function(field) {
             try {
                 // Ensure database is open
                 if (!db) {
                     await openDatabase();
                 }
-                const setting = await getFromStore(STORES.SETTINGS, 'spreadsheet_id');
+                const setting = await getFromStore(STORES.SETTINGS, field);
                 return setting ? setting.value : null;
             } catch (e) {
-                console.error('getStoredSpreadsheetId error:', e);
+                console.error('getStoredLocationId error:', e);
                 return null;
             }
         },

--- a/storage_api.py
+++ b/storage_api.py
@@ -1,4 +1,10 @@
-"""Acquacotta Storage API — dispatch layer for storage backend plugins."""
+"""Acquacotta Storage API — dispatch layer for storage backend plugins.
+
+Every operation dispatches to the backend carried in the request context
+(`ctx["backend"]`), which the caller resolves per-user. The active backend is
+never read from a process-global here, so one user's choice can never route
+another user's data to the wrong backend.
+"""
 
 import plugin_registry
 
@@ -7,71 +13,66 @@ class StorageUnavailable(Exception):
     """Raised when no storage backend is active or context is missing."""
 
 
-def _require_context(ctx):
+def _backend(ctx):
+    """Return the per-user backend from the context, or raise if absent."""
     if ctx is None:
         raise StorageUnavailable()
+    backend = ctx.get("backend")
+    if backend is None:
+        raise StorageUnavailable()
+    return backend
 
 
 def is_active():
-    """Check if a storage backend is active."""
+    """Check if a storage backend is registered (registration-level check)."""
     return plugin_registry.get_active_storage() is not None
 
 
 def get_pomodoros(ctx, start_date=None, end_date=None):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.get_pomodoros(ctx["service"], ctx["location"], start_date, end_date)
 
 
 def save_pomodoro(ctx, pomodoro):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.save_pomodoro(ctx["service"], ctx["location"], pomodoro)
 
 
 def save_pomodoros_batch(ctx, pomodoros):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.save_pomodoros_batch(ctx["service"], ctx["location"], pomodoros)
 
 
 def update_pomodoro(ctx, pomodoro_id, update_fields):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.update_pomodoro(ctx["service"], ctx["location"], pomodoro_id, update_fields)
 
 
 def delete_pomodoro(ctx, pomodoro_id):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.delete_pomodoro(ctx["service"], ctx["location"], pomodoro_id)
 
 
 def get_settings(ctx, defaults):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.get_settings(ctx["service"], ctx["location"], defaults)
 
 
 def save_settings(ctx, settings_data, replace_all=False):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.save_settings(ctx["service"], ctx["location"], settings_data, replace_all=replace_all)
 
 
 def deduplicate_pomodoros(ctx):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.deduplicate_pomodoros(ctx["service"], ctx["location"])
 
 
 def count_pomodoros(ctx):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.count_pomodoros(ctx["service"], ctx["location"])
 
 
 def clear_pomodoros(ctx):
-    _require_context(ctx)
-    backend = plugin_registry.get_active_storage()
+    backend = _backend(ctx)
     return backend.clear_pomodoros(ctx["service"], ctx["location"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -541,7 +541,7 @@
         }
     </style>
     <script src="{{ url_for('static', filename='js/utils.js') }}?v=3"></script>
-    <script src="{{ url_for('static', filename='js/storage.js') }}?v=4"></script>
+    <script src="{{ url_for('static', filename='js/storage.js') }}?v=7"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -824,9 +824,9 @@
                         Your data is stored locally by default. Optionally sign in with Google to sync your data to your Google Drive.
                     </p>
                     <div id="login-spreadsheet-section" style="margin-bottom: 1rem; display: none;">
-                        <label for="login-spreadsheet-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Existing Spreadsheet ID (optional):</label>
+                        <label id="login-location-label" for="login-spreadsheet-id" style="font-size: 0.875rem; color: var(--text-secondary); display: block; margin-bottom: 0.25rem;">Existing Spreadsheet ID (optional):</label>
                         <input type="text" id="login-spreadsheet-id" style="width: 24rem; max-width: 100%; font-family: monospace; font-size: 0.75rem; padding: 0.5rem;" placeholder="Leave blank to create new">
-                        <p style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
+                        <p id="login-location-hint" style="font-size: 0.75rem; color: var(--text-secondary); margin-top: 0.25rem;">
                             Find this in your Google Sheets URL: docs.google.com/spreadsheets/d/<strong>[ID]</strong>/edit
                         </p>
                     </div>
@@ -4456,9 +4456,15 @@
                 } catch (e) {
                     console.error('Sync error:', e);
                 }
-                // Refresh count after init sync (which runs inside Storage.init)
-                // to pick up any pomodoros that were batch-uploaded during init
+                // The bidirectional sync now runs in the BACKGROUND, so this screen
+                // rendered instantly. Show current counts now, then refresh once the
+                // sync settles to pick up merged/batch-uploaded records. The header
+                // indicator shows "Syncing…" → "Synced" while this runs.
                 updateGooglePomodoroCount();
+                Storage.whenInitialSyncDone().then(() => {
+                    updateGooglePomodoroCount();
+                    updateStorageIndicator();
+                });
             }
 
         }
@@ -4817,8 +4823,30 @@
         });
 
         // Listen for sync status changes
+        // Set the cloud card's status line to reflect the live sync state. While the
+        // background bidirectional sync runs, say so plainly; when it settles, confirm.
+        function updateCloudSyncStatusText(pluginName) {
+            const el = document.getElementById('cloud-sync-status-text');
+            if (!el) return;
+            const name = pluginName || (activePluginInfo ? activePluginInfo.name : 'the cloud');
+            const s = Storage.getSyncStatus ? Storage.getSyncStatus() : {};
+            if (s.syncing) {
+                el.textContent = '⟳ Syncing your data with ' + name + '…';
+                el.style.color = 'var(--text-secondary)';
+            } else if (s.pending > 0) {
+                el.textContent = '⟳ ' + s.pending + ' change' + (s.pending === 1 ? '' : 's') + ' pending sync…';
+                el.style.color = 'var(--text-secondary)';
+            } else {
+                el.textContent = '✓ Data synced to ' + name;
+                el.style.color = 'var(--success)';
+            }
+        }
+
         window.addEventListener('acquacotta-sync-status', async (event) => {
             await updateStorageIndicator();
+            if (authStatus && authStatus.logged_in) {
+                updateCloudSyncStatusText();
+            }
         });
 
         async function showInitialSyncModal() {
@@ -4975,19 +5003,26 @@
         }
 
         async function loginWithGoogle() {
-            let spreadsheetId = document.getElementById('login-spreadsheet-id').value.trim();
+            // Which backend is the login form offering? Send the id under the
+            // matching param name so a folder id is never treated as a
+            // spreadsheet id (or vice versa). The server resolves the user's
+            // authoritative backend in the callback regardless; this only
+            // controls which explicit location the user may have typed.
+            const isJsonDrive = activePluginInfo && activePluginInfo.id === 'json-google-drive';
+            const field = isJsonDrive ? 'folder_id' : 'spreadsheet_id';
 
-            // If input is empty, try to get stored spreadsheet ID from IndexedDB
-            if (!spreadsheetId) {
-                const storedId = await Storage.getStoredSpreadsheetId();
+            let locationId = document.getElementById('login-spreadsheet-id').value.trim();
+
+            // If input is empty, try to get the stored id for this backend from IndexedDB
+            if (!locationId) {
+                const storedId = await Storage.getStoredLocationId(field);
                 if (storedId) {
-                    spreadsheetId = storedId;
+                    locationId = storedId;
                 }
             }
 
-            if (spreadsheetId) {
-                // Pass spreadsheet ID as query parameter
-                window.location.href = '/auth/google?spreadsheet_id=' + encodeURIComponent(spreadsheetId);
+            if (locationId) {
+                window.location.href = '/auth/google?' + field + '=' + encodeURIComponent(locationId);
             } else {
                 window.location.href = '/auth/google';
             }
@@ -5023,15 +5058,27 @@
             const isSheets = !activePluginInfo || activePluginInfo.id === 'sheets';
             const pluginName = activePluginInfo ? activePluginInfo.name : 'Google Sheets';
 
-            // Update card title and sync status text
+            // Update card title and sync status text (live sync state, honest while syncing)
             const remoteLabel = isSheets ? 'Remote Data: Sheets' : isJsonDrive ? 'Remote Data: JSON-Google Drive' : 'Remote Data: ' + pluginName;
             document.getElementById('cloud-sync-title').textContent = remoteLabel;
-            document.getElementById('cloud-sync-status-text').textContent = '✓ Data synced to ' + pluginName;
+            updateCloudSyncStatusText(pluginName);
 
-            // Show spreadsheet ID input on login only for Sheets plugin
+            // Show the location-id input on login, labelled for the active backend.
+            // JSON-on-Drive uses a Drive Folder ID; Sheets uses a Spreadsheet ID.
+            // The two are distinct ids and are never conflated.
             const loginSpreadsheetSection = document.getElementById('login-spreadsheet-section');
+            const loginLocationLabel = document.getElementById('login-location-label');
+            const loginLocationHint = document.getElementById('login-location-hint');
             if (loginSpreadsheetSection) {
-                loginSpreadsheetSection.style.display = isSheets ? 'block' : 'none';
+                loginSpreadsheetSection.style.display = 'block';
+                loginSpreadsheetSection.dataset.backend = isJsonDrive ? 'json-google-drive' : 'sheets';
+                if (isJsonDrive) {
+                    if (loginLocationLabel) loginLocationLabel.textContent = 'Existing Drive Folder ID (optional):';
+                    if (loginLocationHint) loginLocationHint.innerHTML = 'Find this in your Google Drive folder URL: drive.google.com/drive/folders/<strong>[ID]</strong>';
+                } else {
+                    if (loginLocationLabel) loginLocationLabel.textContent = 'Existing Spreadsheet ID (optional):';
+                    if (loginLocationHint) loginLocationHint.innerHTML = 'Find this in your Google Sheets URL: docs.google.com/spreadsheets/d/<strong>[ID]</strong>/edit';
+                }
             }
 
             if (authStatus.logged_in) {
@@ -6066,10 +6113,18 @@
 
             // Phase 2b: Restore saved plugin states from IndexedDB.
             // Server-side plugin registry resets on restart; this re-applies user's choices.
+            //
+            // Storage plugins are EXCLUDED: the active storage backend is an
+            // authoritative, per-user, server-side choice resolved per request.
+            // The client must never toggle it on page load — doing so would let
+            // stale browser state overwrite the user's recorded backend choice
+            // (the root cause of JSON users being flipped onto Sheets). See
+            // spec 007-per-user-storage.
             try {
                 const pluginRes = await fetch('/api/plugins');
                 const pluginData = await pluginRes.json();
                 for (const plugin of pluginData.plugins) {
+                    if (plugin.plugin_type === 'storage') continue;
                     const savedState = settings[`plugin_state_${plugin.id}`];
                     if (savedState !== undefined && savedState !== plugin.active) {
                         await fetch('/api/plugins/toggle', {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,9 +9,13 @@ The server only handles:
 All data storage and CRUD operations happen in the browser's IndexedDB.
 """
 
+import base64
 import json
 from unittest.mock import patch
 
+import pytest
+
+import app as app_module
 import storage_api
 
 
@@ -177,20 +181,20 @@ class TestPluginsAPI:
     """Tests for the plugin registry API."""
 
     def test_list_plugins(self, client):
-        """GET /api/plugins should return registered plugins."""
+        """GET /api/plugins should return registered plugins; a request with no
+        recorded user resolves to the default backend (JSON-on-Drive)."""
         response = client.get("/api/plugins")
         assert response.status_code == 200
         data = json.loads(response.data)
         assert "plugins" in data
         assert "types" in data
-        assert "active_storage" in data
-        assert data["active_storage"] == "sheets"
+        assert data["active_storage"] == "json-google-drive"
         sheets_plugin = next(p for p in data["plugins"] if p["id"] == "sheets")
         assert sheets_plugin["name"] == "Google Sheets"
         assert sheets_plugin["plugin_type"] == "storage"
-        assert sheets_plugin["active"] is True
+        assert sheets_plugin["active"] is False
         json_plugin = next(p for p in data["plugins"] if p["id"] == "json-google-drive")
-        assert json_plugin["active"] is False
+        assert json_plugin["active"] is True
 
 
 class TestClearInitialSync:
@@ -267,3 +271,72 @@ class TestStaticPages:
         """Terms page should be accessible."""
         response = client.get("/terms")
         assert response.status_code == 200
+
+
+class TestPerUserBackend:
+    """The storage backend is an authoritative, per-user choice recorded server-side
+    and resolved per request — never a shared global."""
+
+    def _ctx(self, app, creds_dict):
+        header = base64.b64encode(json.dumps(creds_dict).encode()).decode()
+        return app.test_request_context(headers={"X-Credentials": header})
+
+    def test_backend_choice_roundtrip(self, app):
+        with app.test_request_context():
+            app_module.set_user_backend("a@example.com", "json-google-drive")
+            app_module.set_user_backend("b@example.com", "sheets")
+            assert app_module.get_user_backend("a@example.com") == "json-google-drive"
+            assert app_module.get_user_backend("b@example.com") == "sheets"
+            assert app_module.get_user_backend("unset@example.com") is None
+
+    def test_resolves_per_user_and_isolates(self, app):
+        with app.test_request_context():
+            app_module.set_user_backend("a@example.com", "sheets")
+            app_module.set_user_backend("b@example.com", "json-google-drive")
+        with self._ctx(app, {"user_email": "a@example.com"}):
+            assert app_module._active_storage_id() == "sheets"
+        # b's request is unaffected by a's choice
+        with self._ctx(app, {"user_email": "b@example.com"}):
+            assert app_module._active_storage_id() == "json-google-drive"
+
+    def test_unknown_user_gets_default(self, app):
+        with self._ctx(app, {"user_email": "new@example.com"}):
+            assert app_module._active_storage_id() == app_module.DEFAULT_STORAGE_BACKEND
+
+    def test_choice_persists_across_requests(self, app):
+        with self._ctx(app, {"user_email": "c@example.com"}):
+            app_module.set_user_backend("c@example.com", "sheets")
+        # a later, separate request resolves the recorded choice (survives sign-out)
+        with self._ctx(app, {"user_email": "c@example.com"}):
+            assert app_module._active_storage_id() == "sheets"
+
+    def test_location_stored_per_backend(self, app):
+        with app.test_request_context():
+            app_module.save_location("d@example.com", "json-google-drive", "FOLDER1")
+            app_module.save_location("d@example.com", "sheets", "SHEET1")
+            assert app_module.get_stored_location("d@example.com", "json-google-drive") == "FOLDER1"
+            assert app_module.get_stored_location("d@example.com", "sheets") == "SHEET1"
+
+
+class TestStorageApiDispatch:
+    """The data layer dispatches to the backend carried in the request context —
+    never a shared global — so concurrent users never cross backends."""
+
+    def test_dispatches_to_context_backend(self):
+        class FakeBackend:
+            def __init__(self, tag):
+                self.tag = tag
+
+            def get_pomodoros(self, service, location, start_date, end_date):
+                return [self.tag, service, location]
+
+        ctx_a = {"service": "svc-a", "location": "loc-a", "backend": FakeBackend("A")}
+        ctx_b = {"service": "svc-b", "location": "loc-b", "backend": FakeBackend("B")}
+        assert storage_api.get_pomodoros(ctx_a)[0] == "A"
+        assert storage_api.get_pomodoros(ctx_b)[0] == "B"
+
+    def test_missing_backend_raises(self):
+        with pytest.raises(storage_api.StorageUnavailable):
+            storage_api.get_pomodoros({"service": "s", "location": "l"})
+        with pytest.raises(storage_api.StorageUnavailable):
+            storage_api.get_pomodoros(None)


### PR DESCRIPTION
## Summary

Makes each user's storage backend (Google Sheets vs JSON-on-Drive) an **authoritative, per-user, server-recorded choice resolved per request** — never a shared process-global. Fixes the login failures where a JSON user was silently flipped onto Sheets after sign-out and their data never loaded, plus folder/spreadsheet id conflation.

### Server
- `_active_storage_id()` resolves the backend from the **requesting user's** recorded choice (session email in-browser, `X-Credentials` for MCP/API), defaulting to `json-google-drive` only when no user is known.
- `storage_api` dispatches every data operation to the per-user backend carried in the request context (`ctx["backend"]`), not `plugin_registry`'s global — so concurrent users can never cross backends.
- OAuth callback resolves the user's backend, provisions the matching id (folder vs spreadsheet), and records the choice (`set_user_backend`).
- `/api/plugins` and `/api/plugins/toggle` are per-user.

### Client
- Phase-2b restore no longer toggles storage from stale browser state (server is authoritative).
- Login form offers/sends the correct id per backend — folder and spreadsheet ids are never conflated.
- **OAuth callback hands the login off via `sessionStorage`; storage.js (single owner of the IndexedDB schema) persists it on load.** Removes the duplicated schema whose stale DB version threw `VersionError` and silently dropped credentials — the root cause of "login succeeded but stayed logged out."
- Bidirectional sync runs in the **background** so the logged-in card renders instantly; header + card show "Syncing…" → "Synced".

### Constitution note
The server now keeps a minimal per-user routing pointer (email → {backend, location id}) in `user_storage.json`. This is **not** user PII/content — pomodoros, todos, and settings still live solely in the user's own Google storage + browser IndexedDB. See spec 007 Assumptions.

## Test plan
- [x] 207 unit tests pass; ruff clean
- [x] Per-user resolution + isolation, backend-in-context dispatch, location-per-backend round-trip
- [x] Live browser verification: login deterministic, stays on JSON, folder id populates, data loads, instant render + sync feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)