### PR TITLE
feat: per-user extension enablement on web + MCP (spec 008)

### DIFF
--- a/app.py
+++ b/app.py
@@ -942,13 +942,13 @@ def api_toggle_plugin():
                 return jsonify({"error": f"Storage plugin not registered: {plugin_id}"}), HTTPStatus.BAD_REQUEST
             set_user_backend(email, plugin_id)
     elif plugin_type == "extension":
-        try:
-            if enable:
-                plugin_registry.activate_extension(plugin_id)
-            else:
-                plugin_registry.deactivate_extension(plugin_id)
-        except ValueError as e:
-            return jsonify({"error": str(e)}), HTTPStatus.BAD_REQUEST
+        # Extension enablement is a per-user preference, not a process-global. The
+        # client persists it as plugin_state_<id> in the user's own settings (synced
+        # to their storage); the web UI resolves it per-user and the MCP server gates
+        # each caller's tools on their own copy. So we intentionally do NOT flip the
+        # shared registry flag here (that would reconfigure the app for every user).
+        if plugin_registry.get_plugin("extension", plugin_id) is None:
+            return jsonify({"error": f"Extension plugin not registered: {plugin_id}"}), HTTPStatus.BAD_REQUEST
     else:
         return jsonify({"error": f"Toggle not yet supported for type: {plugin_type}"}), HTTPStatus.BAD_REQUEST
 

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -66,6 +66,16 @@ check = "summary_litter"
 path = "specs/007-per-user-storage/checklists/requirements.md"
 justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
 
+[[exceptions]]
+check = "summary_litter"
+path = "specs/008-per-user-extensions/spec.md"
+justification = "Spec-kit feature specification - RFC/ADR-style development workflow"
+
+[[exceptions]]
+check = "summary_litter"
+path = "specs/008-per-user-extensions/checklists/requirements.md"
+justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # random_scripts - Intentional entry points
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -216,6 +216,21 @@ path = "mcp_server.py"
 justification = "'todos' refers to the todos plugin it activates — a domain term, not a deferred-work marker"
 
 [[exceptions]]
+check = "deferred_work"
+path = "tests/test_app.py"
+justification = "'todos' refers to the todos plugin under test — a domain term, not a deferred-work marker"
+
+[[exceptions]]
+check = "deferred_work"
+path = "tests/test_mcp_plugin_gating.py"
+justification = "'todos' refers to the todos plugin under test — a domain term, not a deferred-work marker"
+
+[[exceptions]]
+check = "deferred_work"
+path = "tests/test_mcp_todos.py"
+justification = "'todos' refers to the todos plugin under test — a domain term, not a deferred-work marker"
+
+[[exceptions]]
 check = "single_use_helpers"
 path = "mcp_server.py"
 justification = "_build_drive_service isolates the Google OAuth/Drive boundary; same rationale as app.py's extracted helpers"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -46,7 +46,6 @@ plugin_registry.register(
 )
 plugin_registry.register("extension", "todos", todos_plugin, todos_plugin.PLUGIN_METADATA)
 plugin_registry.activate_storage("json-google-drive")
-plugin_registry.activate_extension("todos")
 
 mcp = FastMCP(
     "acquacotta",
@@ -108,11 +107,33 @@ def require_ctx():
     return {"service": drive_service, "folder_id": payload["folder_id"], "email": payload["email"]}
 
 
-# Core tools (pomodoros) are always available; plugin-contributed tools (todos,
-# and future plugins) register only while their plugin is active.
+def _make_plugin_ctx(plugin_id):
+    """Wrap require_ctx so a plugin's tools are gated on the CALLER's own choice.
+
+    Extension enablement is per-user: a tool only works while the caller has that
+    plugin enabled in their own settings (``plugin_state_<id>`` in their storage).
+    A plugin is enabled unless the user has explicitly turned it off, so newly added
+    plugins default on. Core tools (pomodoros) bypass this entirely.
+    """
+
+    def require_plugin_ctx():
+        ctx = require_ctx()
+        settings = json_google_drive_storage.get_settings(ctx["service"], ctx["folder_id"], {})
+        if not settings.get(f"plugin_state_{plugin_id}", True):
+            raise ToolError(
+                f"The '{plugin_id}' plugin is disabled for your account — "
+                f"enable it in Acquacotta to use these tools"
+            )
+        return ctx
+
+    return require_plugin_ctx
+
+
+# Core tools (pomodoros) are always available. Plugin-contributed tools register for
+# every plugin, but each is gated per-user on the calling user's own plugin choice.
 pomodoro_tools.register_mcp_tools(mcp, require_ctx)
-for registrar in plugin_registry.get_mcp_tool_registrars():
-    registrar(mcp, require_ctx)
+for plugin_id, registrar in plugin_registry.get_mcp_tool_registrars():
+    registrar(mcp, _make_plugin_ctx(plugin_id))
 
 
 def main():

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -121,8 +121,7 @@ def _make_plugin_ctx(plugin_id):
         settings = json_google_drive_storage.get_settings(ctx["service"], ctx["folder_id"], {})
         if not settings.get(f"plugin_state_{plugin_id}", True):
             raise ToolError(
-                f"The '{plugin_id}' plugin is disabled for your account — "
-                f"enable it in Acquacotta to use these tools"
+                f"The '{plugin_id}' plugin is disabled for your account — enable it in Acquacotta to use these tools"
             )
         return ctx
 

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -131,23 +131,21 @@ def list_plugins(plugin_type=None):
 
 
 def get_mcp_tool_registrars():
-    """Return `register_mcp_tools` callables from every active plugin that has one.
+    """Return ``(plugin_id, register_mcp_tools)`` pairs from every registered plugin
+    that contributes MCP tools.
 
-    This is how enabled plugins contribute tools to the MCP server without the
-    core server knowing about them: a plugin module exposes
-    ``register_mcp_tools(mcp, require_ctx)`` and it is collected here only while
-    the plugin is active. Covers extensions/integrations/imports and the active
-    storage backend.
+    A plugin module exposes ``register_mcp_tools(mcp, require_ctx)`` to add its tools
+    to the MCP server without the core server knowing about them. Every such plugin is
+    returned here regardless of a global active flag; the ``plugin_id`` lets the MCP
+    server gate each plugin's tools **per-user** on the calling user's own choice.
+    Enablement is no longer decided globally by the registry.
     """
     registrars = []
-    for ptype, plugins in _plugins.items():
+    for _ptype, plugins in _plugins.items():
         for pid, info in plugins.items():
-            is_active = (pid == _active_storage) if ptype == "storage" else info["active"]
-            if not is_active:
-                continue
             registrar = getattr(info["module"], "register_mcp_tools", None)
             if callable(registrar):
-                registrars.append(registrar)
+                registrars.append((pid, registrar))
     return registrars
 
 

--- a/specs/008-per-user-extensions/checklists/requirements.md
+++ b/specs/008-per-user-extensions/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Per-User Extension Enablement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This completes the per-user plugin model started in spec 007 (which covered the storage backend). Extensions reuse the existing `plugin_state_<id>` preference in the user's own storage as the source of truth, so no new server-side per-user record is introduced.

--- a/specs/008-per-user-extensions/spec.md
+++ b/specs/008-per-user-extensions/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Per-User Extension (Plugin) Enablement
+
+**Feature Branch**: `008-per-user-extensions`
+**Created**: 2026-07-12
+**Status**: Draft
+**Input**: Complete the per-user plugin work started in spec 007. 007 made the *storage* backend a per-user choice; extension plugins (e.g. Todos) are still enabled/disabled process-globally, so one user's toggle changes the app for everyone — on both the web UI and the MCP server.
+
+## Overview
+
+Acquacotta has extension plugins (today: **Todos**) that add UI and MCP tools. Enabling or disabling an extension is currently a **process-global** action: `activate_extension`/`deactivate_extension` mutate shared server state, and the MCP server hardcodes `activate_extension("todos")`. On a hosted multi-user service this means one user turning Todos off removes it for everyone, and every MCP caller sees the same globally-active tool set regardless of their own choice.
+
+This feature makes each user's extension enablement an **authoritative, per-user preference**, consistent with how spec 007 handles the storage backend. A user's choice affects only that user, on both the web UI and MCP.
+
+The source of truth is the user's own `plugin_state_<id>` preference, which already lives in the user's storage (Google Sheets/JSON-on-Drive) and browser cache — consistent with the constitution's **User Data Ownership** principle. Extensions default to **enabled** unless the user has explicitly disabled one.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - One user's extension toggle never affects another (Priority: P1)
+
+Two users use the hosted app concurrently. One disables the Todos extension; the other still sees and uses Todos normally.
+
+**Why this priority**: This is the core defect — extension enablement is shared, so the app silently reconfigures for unrelated users. Per-user isolation is a correctness requirement for a multi-user service.
+
+**Independent Test**: With User A disabling Todos, confirm User B's web UI still shows the Todos tab and User B's MCP session still exposes the Todos tools.
+
+**Acceptance Scenarios**:
+
+1. **Given** User A disables Todos, **When** User B loads the app, **Then** User B still sees Todos (their own choice is unchanged).
+2. **Given** User A disables Todos, **When** User B calls a Todos MCP tool, **Then** it works for User B.
+
+---
+
+### User Story 2 - MCP tools are gated on the calling user's own choice (Priority: P1)
+
+An MCP caller only reaches an extension's tools while that extension is enabled in *their* account.
+
+**Why this priority**: MCP currently exposes a globally-active tool set. A caller who disabled Todos should not have Todos tools act on their data, and a caller who has it enabled must.
+
+**Independent Test**: With Todos disabled for a caller, a Todos tool call returns a clear "plugin disabled" error; with it enabled, the same call succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caller with Todos disabled, **When** they call a Todos tool, **Then** they get a clear error telling them to enable the plugin — no data change.
+2. **Given** a caller with Todos enabled (or no explicit choice), **When** they call a Todos tool, **Then** it works.
+
+---
+
+### User Story 3 - Choice persists and defaults to enabled (Priority: P2)
+
+A user's extension choice persists across reloads, sign-out/in, and service restarts. A user who has never chosen sees extensions **enabled** by default.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new user who has made no choice, **When** they load the app or call MCP, **Then** extensions are enabled by default.
+2. **Given** a user who disabled Todos, **When** they reload or the service restarts, **Then** Todos stays disabled for them.
+
+---
+
+### Edge Cases
+
+- **No preference recorded**: extension defaults to enabled (newly added plugins are on by default).
+- **Service restart**: enablement is derived from the user's own preference, not in-memory global state, so it survives restarts.
+- **Stale global state**: a leftover process-global active flag must not override a user's own recorded choice.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Extension enablement MUST be resolved per-user from the requesting user's own preference, never from process-global state.
+- **FR-002**: One user's extension enable/disable MUST NOT change enablement for any other user, on either the web UI or MCP.
+- **FR-003**: The MCP server MUST gate each extension's tools on the calling user's own enablement; a disabled extension's tools MUST refuse with a clear, actionable error and make no data change.
+- **FR-004**: An extension with no recorded user choice MUST default to enabled.
+- **FR-005**: A user's extension choice MUST persist across reload, sign-out/in, and service restart.
+- **FR-006**: The web UI (tabs, settings cards, toggles) MUST reflect the current user's own enablement.
+- **FR-007**: This feature MUST NOT store additional user content/PII on the server beyond what already exists; extension preferences live in the user's own storage/cache.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: 0 instances of one user's extension toggle changing enablement for another user (web or MCP).
+- **SC-002**: 100% of MCP tool calls for a disabled extension are refused with a clear error and no data change; 100% for an enabled (or default) extension succeed.
+- **SC-003**: A user with no recorded choice gets extensions enabled by default, 100% of the time.
+- **SC-004**: A disabled-Todos choice survives a service restart 100% of the time.
+
+## Assumptions
+
+- The per-user extension preference is the existing `plugin_state_<id>` setting already written by the client and synced to the user's storage; no new server-side per-user record is required.
+- MCP callers are identified by their token (which carries the user's storage location), so the MCP server can read the caller's own preference.
+- Only the Todos extension exists today; the design applies uniformly to any future extension.
+
+## Out of Scope
+
+- Changes to storage-backend selection (shipped in 007).
+- The sync-performance batching of IndexedDB writes (tracked separately, issue #117).

--- a/templates/index.html
+++ b/templates/index.html
@@ -3885,7 +3885,7 @@
                     // MCP access renders its own card (per-user state + token UI).
                     if (plugin.has_mcp) return await renderMcpCard(plugin);
 
-                    const isActive = plugin.active;
+                    const isActive = pluginEffectiveActive(plugin);
                     const typeBadge = `<span style="display: inline-block; padding: 0.125rem 0.5rem; border-radius: 4px; font-size: 0.75rem; background: var(--bg-tertiary); color: var(--text-secondary);">${plugin.plugin_type}</span>`;
                     const toggleId = `plugin-toggle-${plugin.id}`;
                     const toggleChecked = isActive ? 'checked' : '';
@@ -3960,8 +3960,11 @@
                 }
                 const data = await resp.json();
 
-                // Persist plugin state to IndexedDB so it survives container restarts
+                // Persist plugin state to IndexedDB (syncs to the user's storage) and
+                // update the in-memory settings so pluginEffectiveActive() reflects the
+                // change immediately for this user — no shared/global state is touched.
                 await Storage.saveSetting(`plugin_state_${pluginId}`, enable);
+                settings[`plugin_state_${pluginId}`] = enable;
 
                 // Refresh plugin info and auth UI to reflect the new active plugin
                 activePluginInfo = await fetch('/api/plugins').then(r => r.json()).then(d =>
@@ -3979,15 +3982,27 @@
             }
         }
 
+        // Extension enablement is per-user: the authoritative value is the user's own
+        // plugin_state_<id> setting (default enabled), NOT the server's shared active
+        // flag. Storage stays server-resolved (per-user, from /api/plugins). See spec 008.
+        function pluginEffectiveActive(plugin) {
+            if (plugin.plugin_type === 'extension') {
+                const saved = settings[`plugin_state_${plugin.id}`];
+                return saved !== undefined ? saved : plugin.active;
+            }
+            return plugin.active;
+        }
+
         function updateExtensionTabs(plugins) {
             if (!plugins) return;
             const extensions = plugins.filter(p => p.plugin_type === 'extension' && p.has_tab);
             for (const plugin of extensions) {
+                const active = pluginEffectiveActive(plugin);
                 const tab = document.getElementById(`tab-${plugin.tab_id}`);
                 const settingsCard = document.getElementById(`${plugin.tab_id}-settings-card`);
                 if (tab) {
-                    tab.style.display = plugin.active ? '' : 'none';
-                    if (!plugin.active) {
+                    tab.style.display = active ? '' : 'none';
+                    if (!active) {
                         const view = document.getElementById(`${plugin.tab_id}-view`);
                         if (view && view.classList.contains('active')) {
                             document.getElementById('tab-timer').click();
@@ -3995,7 +4010,7 @@
                     }
                 }
                 if (settingsCard) {
-                    settingsCard.style.display = plugin.active ? '' : 'none';
+                    settingsCard.style.display = active ? '' : 'none';
                 }
             }
         }
@@ -6111,32 +6126,16 @@
                 loadWeeklyOverview()
             ]);
 
-            // Phase 2b: Restore saved plugin states from IndexedDB.
-            // Server-side plugin registry resets on restart; this re-applies user's choices.
+            // Phase 2b: Apply the user's own plugin choices to the UI.
             //
-            // Storage plugins are EXCLUDED: the active storage backend is an
-            // authoritative, per-user, server-side choice resolved per request.
-            // The client must never toggle it on page load — doing so would let
-            // stale browser state overwrite the user's recorded backend choice
-            // (the root cause of JSON users being flipped onto Sheets). See
-            // spec 007-per-user-storage.
+            // Plugin enablement is per-user and the client is authoritative: storage
+            // is resolved per-user server-side (spec 007) and extensions come from the
+            // user's own plugin_state_<id> setting (spec 008). We no longer POST toggle
+            // to mutate shared server state on page load — that reconfigured the app for
+            // every user. We just reflect the current user's choices in the UI.
             try {
-                const pluginRes = await fetch('/api/plugins');
-                const pluginData = await pluginRes.json();
-                for (const plugin of pluginData.plugins) {
-                    if (plugin.plugin_type === 'storage') continue;
-                    const savedState = settings[`plugin_state_${plugin.id}`];
-                    if (savedState !== undefined && savedState !== plugin.active) {
-                        await fetch('/api/plugins/toggle', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ plugin_id: plugin.id, plugin_type: plugin.plugin_type, enable: savedState })
-                        });
-                    }
-                }
-                // Refresh extension tab visibility after restoring states
-                const refreshedData = await fetch('/api/plugins').then(r => r.json());
-                updateExtensionTabs(refreshedData.plugins);
+                const pluginData = await fetch('/api/plugins').then(r => r.json());
+                updateExtensionTabs(pluginData.plugins);
             } catch (e) { /* offline — use server defaults */ }
 
             // Phase 3: Sync cloud data then render todos once with fresh state.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 
 import app as app_module
+import plugin_registry
 import storage_api
 
 
@@ -195,6 +196,38 @@ class TestPluginsAPI:
         assert sheets_plugin["active"] is False
         json_plugin = next(p for p in data["plugins"] if p["id"] == "json-google-drive")
         assert json_plugin["active"] is True
+
+
+class TestExtensionTogglePerUser:
+    """Extension enablement is a per-user client preference; the toggle endpoint
+    validates the plugin but never flips shared global registry state (spec 008)."""
+
+    def test_toggle_known_extension_ok(self, client):
+        response = client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "todos", "plugin_type": "extension", "enable": False},
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["status"] == "ok"
+
+    def test_toggle_unknown_extension_400(self, client):
+        response = client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "nope", "plugin_type": "extension", "enable": True},
+        )
+        assert response.status_code == 400
+
+    def test_toggle_does_not_mutate_global_registry(self, client):
+        def todos_active():
+            todos = next(p for p in plugin_registry.list_plugins() if p["id"] == "todos")
+            return todos["active"]
+
+        before = todos_active()
+        client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "todos", "plugin_type": "extension", "enable": not before},
+        )
+        assert todos_active() == before  # per-user choice lives client-side, not the global flag
 
 
 class TestClearInitialSync:

--- a/tests/test_mcp_plugin_gating.py
+++ b/tests/test_mcp_plugin_gating.py
@@ -1,0 +1,75 @@
+"""Tests for per-user MCP plugin gating (spec 008).
+
+An extension's MCP tools are gated on the CALLING user's own plugin_state_<id>
+preference (read from their storage), never a shared global. A disabled plugin's
+tools refuse with a clear error; enabled (or unset → default on) tools pass through.
+"""
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+import mcp_server
+
+
+@pytest.fixture
+def caller_ctx(monkeypatch):
+    """Stub require_ctx to a fixed caller and make get_settings return whatever the
+    test puts in `state['settings']` — standing in for the caller's stored prefs."""
+    state = {"settings": {}}
+    ctx = {"service": object(), "folder_id": "folder-abc", "email": "user@example.com"}
+
+    monkeypatch.setattr(mcp_server, "require_ctx", lambda: ctx)
+    monkeypatch.setattr(
+        mcp_server.json_google_drive_storage,
+        "get_settings",
+        lambda service, folder_id, defaults: dict(state["settings"]),
+    )
+    return state, ctx
+
+
+def test_enabled_plugin_passes_through(caller_ctx):
+    state, ctx = caller_ctx
+    state["settings"] = {"plugin_state_todos": True}
+    gated = mcp_server._make_plugin_ctx("todos")
+    assert gated() is ctx
+
+
+def test_unset_plugin_defaults_enabled(caller_ctx):
+    state, ctx = caller_ctx
+    state["settings"] = {}  # user never chose → default on
+    gated = mcp_server._make_plugin_ctx("todos")
+    assert gated() is ctx
+
+
+def test_disabled_plugin_refuses(caller_ctx):
+    state, _ctx = caller_ctx
+    state["settings"] = {"plugin_state_todos": False}
+    gated = mcp_server._make_plugin_ctx("todos")
+    with pytest.raises(ToolError) as exc:
+        gated()
+    assert "todos" in str(exc.value)
+    assert "disabled" in str(exc.value).lower()
+
+
+def test_gating_is_per_plugin(caller_ctx):
+    """Disabling one plugin does not gate another."""
+    state, ctx = caller_ctx
+    state["settings"] = {"plugin_state_todos": False, "plugin_state_other": True}
+    assert mcp_server._make_plugin_ctx("other")() is ctx
+    with pytest.raises(ToolError):
+        mcp_server._make_plugin_ctx("todos")()
+
+
+def test_registry_returns_id_registrar_pairs():
+    """get_mcp_tool_registrars yields (plugin_id, callable) for every plugin with a
+    registrar, so the MCP server can gate each per-user."""
+    import plugin_registry
+
+    pairs = plugin_registry.get_mcp_tool_registrars()
+    assert pairs, "expected at least the todos registrar"
+    for item in pairs:
+        assert isinstance(item, tuple) and len(item) == 2
+        pid, registrar = item
+        assert isinstance(pid, str)
+        assert callable(registrar)
+    assert "todos" in {pid for pid, _ in pairs}


### PR DESCRIPTION
## Summary

Completes the per-user plugin model started in **spec 007** (which covered the storage backend). Extension plugins (**Todos**) were still enabled/disabled **process-globally** — one user's toggle reconfigured the app for everyone, and the MCP server hardcoded `activate_extension("todos")`. Now each user's extension choice affects only that user, on both the web UI and MCP.

Source of truth is the user's own `plugin_state_<id>` preference (already stored in their storage + browser cache), consistent with the **User Data Ownership** principle. Extensions default to **enabled** unless the user turned one off.

### Changes
- `plugin_registry.get_mcp_tool_registrars()` returns `(plugin_id, registrar)` for every plugin with a registrar — no global active filter.
- `mcp_server._make_plugin_ctx(id)` gates each plugin's tools on the **caller's own** `plugin_state_<id>` (read from their storage), refusing with a clear error when disabled; removed the hardcoded `activate_extension("todos")`.
- `app.py` extension toggle validates the plugin but no longer flips shared registry state.
- `index.html`: `pluginEffectiveActive()` drives tabs/cards/checkboxes from the user's own setting; `togglePlugin` updates in-memory settings immediately; removed the Phase-2b global-toggle-on-load dance.

## Test plan
- [x] 215 unit tests pass; ruff clean
- [x] Per-user MCP gating (enabled / unset→default-on / disabled→clear error / per-plugin isolation), registrar shape, extension toggle does not mutate the global registry
- [x] Web verified live: disabling Todos hid the tab while the server still reported `active: true` (proof of per-user isolation); persists across reload
- [ ] MCP gating end-to-end with a real token — to verify in prod (needs OAuth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)