### PR TITLE
feat: everything-is-a-plugin, mandatory + optional (009)

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 import json_google_drive_storage
 import mcp_tokens
 import plugin_registry
+import pomodoro_tools
 import sheets_storage
 import storage_api
 import todos_plugin
@@ -44,6 +45,25 @@ plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLU
 plugin_registry.register(
     "storage", "json-google-drive", json_google_drive_storage, json_google_drive_storage.PLUGIN_METADATA
 )
+
+# Mandatory feature plugins — always registered, always enabled, never toggleable.
+# Pomodoro carries MCP tools; Settings is UI-only (metadata registration is enough,
+# like the MCP plugin below).
+plugin_registry.register("extension", "pomodoro", pomodoro_tools, pomodoro_tools.PLUGIN_METADATA)
+SETTINGS_PLUGIN_METADATA = {
+    "id": "settings",
+    "name": "Settings",
+    "description": "App preferences and timer configuration",
+    "version": "1.0.0",
+    "type": "extension",
+    "author": "Crunchtools",
+    "mandatory": True,
+}
+plugin_registry.register("extension", "settings", SimpleNamespace(), SETTINGS_PLUGIN_METADATA)
+
+# Todos — optional plugin, per-user enable/disable (spec 008). activate_extension sets
+# the registry default to on; the per-user choice (plugin_state_todos) governs actual
+# enablement on web and MCP.
 plugin_registry.register("extension", "todos", todos_plugin, todos_plugin.PLUGIN_METADATA)
 plugin_registry.activate_extension("todos")
 
@@ -949,6 +969,11 @@ def api_toggle_plugin():
         # shared registry flag here (that would reconfigure the app for every user).
         if plugin_registry.get_plugin("extension", plugin_id) is None:
             return jsonify({"error": f"Extension plugin not registered: {plugin_id}"}), HTTPStatus.BAD_REQUEST
+        # Mandatory plugins (Pomodoro, Settings) can never be disabled (spec 009).
+        if plugin_registry.is_mandatory("extension", plugin_id):
+            return jsonify(
+                {"error": f"'{plugin_id}' is a required plugin and cannot be disabled"}
+            ), HTTPStatus.FORBIDDEN
     else:
         return jsonify({"error": f"Toggle not yet supported for type: {plugin_type}"}), HTTPStatus.BAD_REQUEST
 

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -76,6 +76,16 @@ check = "summary_litter"
 path = "specs/008-per-user-extensions/checklists/requirements.md"
 justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
 
+[[exceptions]]
+check = "summary_litter"
+path = "specs/009-mandatory-plugins/spec.md"
+justification = "Spec-kit feature specification - RFC/ADR-style development workflow"
+
+[[exceptions]]
+check = "summary_litter"
+path = "specs/009-mandatory-plugins/checklists/requirements.md"
+justification = "Spec-kit requirements checklist - RFC/ADR-style development workflow"
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # random_scripts - Intentional entry points
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -227,6 +227,11 @@ justification = "'todos' refers to the todos plugin it activates — a domain te
 
 [[exceptions]]
 check = "deferred_work"
+path = "app.py"
+justification = "'todos' refers to the todos plugin it registers — a domain term, not a deferred-work marker"
+
+[[exceptions]]
+check = "deferred_work"
 path = "tests/test_app.py"
 justification = "'todos' refers to the todos plugin under test — a domain term, not a deferred-work marker"
 
@@ -249,6 +254,16 @@ justification = "_build_drive_service isolates the Google OAuth/Drive boundary; 
 check = "verbose_comments"
 path = "mcp_server.py"
 justification = "Comments document the sealed-token auth and per-user epoch revocation model"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "plugin_registry.py"
+justification = "Comments document the plugin type system, mandatory/optional model, and MCP registrar contract"
+
+[[exceptions]]
+check = "verbose_comments"
+path = "pomodoro_tools.py"
+justification = "Comments document the pomodoro plugin metadata and MCP tool contract"
 
 [[exceptions]]
 check = "verbose_comments"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -38,12 +38,14 @@ SCOPES = [
 ]
 
 # Register the plugins the MCP server exposes. Drive-backed storage is the MCP
-# backend (tokens carry a folder_id); todos is an active extension. This mirrors
-# the web app's registration but is self-contained so we never import Flask.
+# backend (tokens carry a folder_id). Pomodoro is a mandatory plugin (its tools are
+# always available); Todos is an optional plugin (per-user gated). This mirrors the
+# web app's registration but is self-contained so we never import Flask.
 plugin_registry.register("storage", "sheets", sheets_storage, sheets_storage.PLUGIN_METADATA)
 plugin_registry.register(
     "storage", "json-google-drive", json_google_drive_storage, json_google_drive_storage.PLUGIN_METADATA
 )
+plugin_registry.register("extension", "pomodoro", pomodoro_tools, pomodoro_tools.PLUGIN_METADATA)
 plugin_registry.register("extension", "todos", todos_plugin, todos_plugin.PLUGIN_METADATA)
 plugin_registry.activate_storage("json-google-drive")
 
@@ -128,11 +130,11 @@ def _make_plugin_ctx(plugin_id):
     return require_plugin_ctx
 
 
-# Core tools (pomodoros) are always available. Plugin-contributed tools register for
-# every plugin, but each is gated per-user on the calling user's own plugin choice.
-pomodoro_tools.register_mcp_tools(mcp, require_ctx)
-for plugin_id, registrar in plugin_registry.get_mcp_tool_registrars():
-    registrar(mcp, _make_plugin_ctx(plugin_id))
+# Every plugin's tools register through the same path. Mandatory plugins (Pomodoro)
+# use require_ctx directly — always available; optional plugins (Todos) are gated
+# per-user on the calling user's own plugin choice (spec 008/009).
+for plugin_id, registrar, mandatory in plugin_registry.get_mcp_tool_registrars():
+    registrar(mcp, require_ctx if mandatory else _make_plugin_ctx(plugin_id))
 
 
 def main():

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -52,11 +52,21 @@ def register(plugin_type, plugin_id, module, metadata):
     if plugin_type not in _plugins:
         _plugins[plugin_type] = {}
 
+    # Mandatory plugins (e.g. Pomodoro, Settings) are always registered and enabled;
+    # they cannot be disabled by any user or interface. Optional plugins default off
+    # and are governed per-user (spec 008).
+    mandatory = bool(metadata.get("mandatory", False))
     _plugins[plugin_type][plugin_id] = {
         "module": module,
         "metadata": metadata,
-        "active": False,
+        "active": mandatory,
+        "mandatory": mandatory,
     }
+
+
+def is_mandatory(plugin_type, plugin_id):
+    """True if the plugin is registered and marked mandatory (always-on)."""
+    return bool(_plugins.get(plugin_type, {}).get(plugin_id, {}).get("mandatory", False))
 
 
 def activate_storage(plugin_id):
@@ -123,7 +133,9 @@ def list_plugins(plugin_type=None):
             continue
         for _pid, info in _plugins[ptype].items():
             entry = dict(info["metadata"])
-            entry["active"] = info["active"]
+            # Mandatory plugins are always active; otherwise report the registry flag.
+            entry["active"] = True if info["mandatory"] else info["active"]
+            entry["mandatory"] = info["mandatory"]
             entry["plugin_type"] = ptype
             plugin_summaries.append(entry)
 
@@ -131,13 +143,14 @@ def list_plugins(plugin_type=None):
 
 
 def get_mcp_tool_registrars():
-    """Return ``(plugin_id, register_mcp_tools)`` pairs from every registered plugin
-    that contributes MCP tools.
+    """Return ``(plugin_id, register_mcp_tools, mandatory)`` triples from every
+    registered plugin that contributes MCP tools.
 
     A plugin module exposes ``register_mcp_tools(mcp, require_ctx)`` to add its tools
     to the MCP server without the core server knowing about them. Every such plugin is
-    returned here regardless of a global active flag; the ``plugin_id`` lets the MCP
-    server gate each plugin's tools **per-user** on the calling user's own choice.
+    returned here; the ``plugin_id`` and ``mandatory`` flag let the MCP server gate
+    each plugin's tools appropriately — mandatory plugins are always available, while
+    optional plugins are gated **per-user** on the calling user's own choice (spec 008).
     Enablement is no longer decided globally by the registry.
     """
     registrars = []
@@ -145,7 +158,7 @@ def get_mcp_tool_registrars():
         for pid, info in plugins.items():
             registrar = getattr(info["module"], "register_mcp_tools", None)
             if callable(registrar):
-                registrars.append((pid, registrar))
+                registrars.append((pid, registrar, info["mandatory"]))
     return registrars
 
 

--- a/plugin_registry.py
+++ b/plugin_registry.py
@@ -52,9 +52,7 @@ def register(plugin_type, plugin_id, module, metadata):
     if plugin_type not in _plugins:
         _plugins[plugin_type] = {}
 
-    # Mandatory plugins (e.g. Pomodoro, Settings) are always registered and enabled;
-    # they cannot be disabled by any user or interface. Optional plugins default off
-    # and are governed per-user (spec 008).
+    # Mandatory plugins register active and can never be disabled; others default off.
     mandatory = bool(metadata.get("mandatory", False))
     _plugins[plugin_type][plugin_id] = {
         "module": module,
@@ -143,15 +141,9 @@ def list_plugins(plugin_type=None):
 
 
 def get_mcp_tool_registrars():
-    """Return ``(plugin_id, register_mcp_tools, mandatory)`` triples from every
-    registered plugin that contributes MCP tools.
-
-    A plugin module exposes ``register_mcp_tools(mcp, require_ctx)`` to add its tools
-    to the MCP server without the core server knowing about them. Every such plugin is
-    returned here; the ``plugin_id`` and ``mandatory`` flag let the MCP server gate
-    each plugin's tools appropriately — mandatory plugins are always available, while
-    optional plugins are gated **per-user** on the calling user's own choice (spec 008).
-    Enablement is no longer decided globally by the registry.
+    """Return ``(plugin_id, register_mcp_tools, mandatory)`` triples for every plugin
+    exposing ``register_mcp_tools``. The MCP server uses ``mandatory`` to decide gating:
+    mandatory plugins are always available; optional ones are gated per-user (spec 008).
     """
     registrars = []
     for _ptype, plugins in _plugins.items():

--- a/pomodoro_tools.py
+++ b/pomodoro_tools.py
@@ -10,6 +10,19 @@ from datetime import datetime, timedelta, timezone
 
 import json_google_drive_storage as drive_storage
 
+# Pomodoro is a mandatory feature plugin: time tracking is core to Acquacotta, so it
+# is always registered and enabled and cannot be disabled. Its MCP tools (below) are
+# therefore always available to every authenticated caller.
+PLUGIN_METADATA = {
+    "id": "pomodoro",
+    "name": "Pomodoro",
+    "description": "Pomodoro time tracking — the core of Acquacotta",
+    "version": "1.0.0",
+    "type": "extension",
+    "author": "Crunchtools",
+    "mandatory": True,
+}
+
 
 def _iso_z(dt):
     """ISO 8601 with a trailing 'Z', matching the timestamps the web UI writes."""

--- a/pomodoro_tools.py
+++ b/pomodoro_tools.py
@@ -10,9 +10,7 @@ from datetime import datetime, timedelta, timezone
 
 import json_google_drive_storage as drive_storage
 
-# Pomodoro is a mandatory feature plugin: time tracking is core to Acquacotta, so it
-# is always registered and enabled and cannot be disabled. Its MCP tools (below) are
-# therefore always available to every authenticated caller.
+# Mandatory feature plugin — always registered; its MCP tools (below) are always available.
 PLUGIN_METADATA = {
     "id": "pomodoro",
     "name": "Pomodoro",

--- a/specs/009-mandatory-plugins/checklists/requirements.md
+++ b/specs/009-mandatory-plugins/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Everything-is-a-Plugin (Mandatory + Optional)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Builds directly on spec 007 (per-user storage) and 008 (per-user optional plugins). The key scoping decision — first-class plugins at the registry/UI/MCP layer, but keeping the storage-backend persistence contract intact — is called out explicitly in Out of Scope for stakeholder review; pulling the storage-decoupling in would materially enlarge the effort.

--- a/specs/009-mandatory-plugins/spec.md
+++ b/specs/009-mandatory-plugins/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Everything-is-a-Plugin (Mandatory + Optional Plugins)
+
+**Feature Branch**: `feature/009-mandatory-plugins`
+**Created**: 2026-07-13
+**Status**: Draft
+**Input**: "Pomodoro, Settings, and Todos should all be plugins. Pomodoro and Settings should be mandatory plugins." (queued after specs 007/008)
+
+## Overview
+
+Acquacotta's features are currently modeled inconsistently. **Todos** is a first-class plugin (registered, has a tab, contributes MCP tools, per-user enable/disable from spec 008). **Pomodoros** are "core" — their MCP tools are hardcoded into the MCP server and their data operations live inside the storage-backend contract, but there is no "pomodoro plugin." **Settings** is neither a plugin nor a tab — just a view plus two functions on the storage contract. So "what features exist" is expressed three different ways.
+
+This feature unifies the model: **every user-facing feature is a plugin.** Pomodoro, Settings, and Todos are all registered plugins listed uniformly. Two of them — **Pomodoro and Settings** — are **mandatory**: always registered, always enabled, and not user-toggleable (the app is meaningless without them). Todos remains an **optional** plugin the user can enable/disable per-user (spec 008 behavior, unchanged).
+
+The result: one consistent plugin model across the registry, the web Plugins UI, and the MCP server — with a clear, enforced distinction between mandatory features and optional ones.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every feature appears uniformly as a plugin (Priority: P1)
+
+A user opens Settings → Plugins and sees Pomodoro, Settings, and Todos listed the same way as any plugin, each showing whether it is mandatory or optional.
+
+**Why this priority**: Today the plugin list only shows Todos (and storage/MCP). Pomodoro and Settings are invisible as plugins, so the "everything is a plugin" model isn't real or inspectable.
+
+**Independent Test**: Load the Plugins list; confirm Pomodoro, Settings, and Todos are all present, with Pomodoro and Settings clearly marked mandatory.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Plugins list, **When** it renders, **Then** Pomodoro, Settings, and Todos are all shown as plugins.
+2. **Given** a mandatory plugin (Pomodoro or Settings), **When** it is shown, **Then** it is marked mandatory and presents no working "disable" control.
+
+---
+
+### User Story 2 - Mandatory plugins cannot be disabled (Priority: P1)
+
+A user (or an API/MCP caller) cannot turn off Pomodoro or Settings; they are always on for everyone.
+
+**Why this priority**: These features are foundational — disabling them would break the app. "Mandatory" must be enforced, not merely labeled.
+
+**Independent Test**: Attempt to disable Pomodoro (or Settings) via the UI toggle and via the toggle API; confirm it stays enabled and the attempt is rejected/ignored. Confirm their MCP tools always work.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mandatory plugin, **When** a disable is attempted through any interface, **Then** it remains enabled and the attempt is refused (no state change).
+2. **Given** a mandatory plugin, **When** any user calls its MCP tools, **Then** they always work, regardless of that user's other plugin choices.
+
+---
+
+### User Story 3 - Optional plugins keep their per-user enable/disable (Priority: P1)
+
+Todos remains an optional plugin each user can enable or disable for themselves, exactly as in spec 008, on both web and MCP.
+
+**Why this priority**: This feature must not regress the per-user optional-plugin behavior just shipped in 008.
+
+**Independent Test**: Disable Todos for one user; confirm its tab hides and its MCP tools refuse for that user, while another user is unaffected — unchanged from 008.
+
+**Acceptance Scenarios**:
+
+1. **Given** Todos (optional), **When** a user disables it, **Then** its tab hides and its MCP tools refuse for that user only.
+2. **Given** Todos disabled for user A, **When** user B uses the app, **Then** Todos is unaffected for user B.
+
+---
+
+### User Story 4 - Consistent behavior after restart and across interfaces (Priority: P2)
+
+Mandatory plugins are always present after a service restart with no per-user state; optional-plugin choices persist per-user. The web UI and MCP agree on which plugins are mandatory vs optional and on each user's enablement.
+
+**Acceptance Scenarios**:
+
+1. **Given** a service restart, **When** any user connects, **Then** Pomodoro and Settings are registered and enabled without any stored per-user state.
+2. **Given** the same user on web and MCP, **When** they inspect plugins, **Then** both interfaces report the same mandatory/optional classification and the same enablement for optional plugins.
+
+---
+
+### Edge Cases
+
+- **Attempt to disable a mandatory plugin via a crafted API/MCP call**: refused; no state change; feature stays enabled.
+- **A user's stored preference says a mandatory plugin is off** (stale/imported data): ignored — mandatory always wins.
+- **A newly added optional plugin with no recorded choice**: defaults enabled (unchanged from 008).
+- **Registry lists a mandatory plugin**: it is always `active`, independent of any per-user setting.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Pomodoro, Settings, and Todos MUST each be modeled and listed as plugins through the same registry and Plugins UI.
+- **FR-002**: The system MUST distinguish **mandatory** plugins (Pomodoro, Settings) from **optional** plugins (Todos), and expose that classification to the web UI and MCP.
+- **FR-003**: Mandatory plugins MUST always be registered and enabled, independent of any per-user preference or process state, including after a service restart.
+- **FR-004**: The system MUST refuse any attempt (UI, API, or MCP) to disable a mandatory plugin, making no state change.
+- **FR-005**: Mandatory plugins' MCP tools MUST always be available to every authenticated caller (never gated off).
+- **FR-006**: Optional plugins MUST retain per-user enable/disable on web and MCP exactly as defined in spec 008 (no regression).
+- **FR-007**: The web Plugins UI MUST list every plugin (Pomodoro, Settings, Todos). Mandatory plugins MUST render with a **checked, disabled (locked)** toggle and a **"Required"** badge — visibly on and clearly non-changeable. Optional plugins MUST render with their normal per-user toggle (checked by default, user-changeable).
+- **FR-008**: The web UI and MCP MUST agree on the mandatory/optional classification and on each user's optional-plugin enablement.
+- **FR-009**: This change MUST NOT alter how any feature's data is stored or its on-the-wire/on-disk data format (no user-data migration).
+
+### Key Entities
+
+- **Plugin**: a registered feature with an id, display metadata, a classification (**mandatory** or **optional**), and optional contributions (a UI tab, MCP tools). Pomodoro, Settings, Todos are plugins; storage backends and MCP-access remain their own plugin categories.
+- **Mandatory Plugin**: a Plugin that is always registered and enabled and cannot be disabled by any user or interface.
+- **Optional Plugin**: a Plugin whose enablement is a per-user choice (spec 008), defaulting to enabled.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: 100% of the three features (Pomodoro, Settings, Todos) appear as plugins in the registry and Plugins UI.
+- **SC-002**: 0 successful attempts to disable a mandatory plugin via any interface.
+- **SC-003**: Mandatory plugins' MCP tools succeed for 100% of authenticated callers regardless of their other plugin choices.
+- **SC-004**: Optional-plugin per-user behavior (spec 008) passes 100% of its existing checks (no regression).
+- **SC-005**: No change to stored data or data formats — verifiable by diffing what is persisted before/after.
+
+## Assumptions
+
+- "Mandatory" is expressed as plugin classification/metadata plus registry enforcement — not by writing per-user state (mandatory plugins need no per-user record).
+- Pomodoro's existing MCP tools are re-homed from hardcoded "core" registration onto the Pomodoro plugin, keeping the same tool names and behavior.
+- Settings may have no MCP tools today; as a mandatory plugin it still appears in the registry/UI and is always-on. Adding Settings MCP tools is not required by this spec.
+- Per-user optional-plugin state continues to use the existing `plugin_state_<id>` preference from spec 008.
+
+## Out of Scope
+
+- **Decoupling the storage-backend contract** (moving pomodoro/settings persistence out of the storage plugin's fat contract into the feature plugins). This spec makes features first-class plugins at the registry/UI/MCP layer; the persistence layer keeps its current shape. A future spec may separate "what feature" from "where stored."
+- Adding new MCP tools for Settings.
+- Any change to storage-backend selection (spec 007) or to the per-user optional-plugin mechanism itself (spec 008).
+- Data migration of any kind.

--- a/templates/index.html
+++ b/templates/index.html
@@ -541,7 +541,7 @@
         }
     </style>
     <script src="{{ url_for('static', filename='js/utils.js') }}?v=3"></script>
-    <script src="{{ url_for('static', filename='js/storage.js') }}?v=8"></script>
+    <script src="{{ url_for('static', filename='js/storage.js') }}?v=9"></script>
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -3926,11 +3926,11 @@
                             </div>
                             ${actions}
                         </div>
-                        <label style="display: flex; align-items: center; cursor: pointer; gap: 0.5rem; margin-left: 1rem;">
-                            <span style="font-size: 0.75rem; color: ${isActive ? 'var(--success)' : 'var(--text-secondary)'};">${isActive ? 'On' : 'Off'}</span>
-                            <input type="checkbox" id="${toggleId}" ${toggleChecked}
+                        <label style="display: flex; align-items: center; ${plugin.mandatory ? '' : 'cursor: pointer;'} gap: 0.5rem; margin-left: 1rem;" ${plugin.mandatory ? 'title="This plugin is required and cannot be disabled"' : ''}>
+                            <span style="font-size: 0.75rem; color: ${plugin.mandatory ? 'var(--text-secondary)' : (isActive ? 'var(--success)' : 'var(--text-secondary)')};">${plugin.mandatory ? 'Required' : (isActive ? 'On' : 'Off')}</span>
+                            <input type="checkbox" id="${toggleId}" ${toggleChecked} ${plugin.mandatory ? 'disabled' : ''}
                                 data-plugin-id="${plugin.id}" data-plugin-type="${plugin.plugin_type}"
-                                onchange="togglePlugin(this)" style="width: auto; cursor: pointer;">
+                                onchange="togglePlugin(this)" style="width: auto; ${plugin.mandatory ? 'cursor: not-allowed;' : 'cursor: pointer;'}">
                         </label>
                     </div>`;
                 });
@@ -3986,6 +3986,8 @@
         // plugin_state_<id> setting (default enabled), NOT the server's shared active
         // flag. Storage stays server-resolved (per-user, from /api/plugins). See spec 008.
         function pluginEffectiveActive(plugin) {
+            // Mandatory plugins (Pomodoro, Settings) are always on — no per-user override.
+            if (plugin.mandatory) return true;
             if (plugin.plugin_type === 'extension') {
                 const saved = settings[`plugin_state_${plugin.id}`];
                 return saved !== undefined ? saved : plugin.active;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -230,6 +230,48 @@ class TestExtensionTogglePerUser:
         assert todos_active() == before  # per-user choice lives client-side, not the global flag
 
 
+class TestMandatoryPlugins:
+    """Pomodoro and Settings are mandatory plugins: listed, always-on, non-toggleable
+    (spec 009). Todos remains an optional plugin."""
+
+    def test_features_listed_as_plugins(self, client):
+        response = client.get("/api/plugins")
+        plugins = {p["id"]: p for p in json.loads(response.data)["plugins"]}
+        for pid in ("pomodoro", "settings", "todos"):
+            assert pid in plugins, f"{pid} should be listed as a plugin"
+
+    def test_mandatory_flags_and_always_active(self, client):
+        plugins = {p["id"]: p for p in json.loads(client.get("/api/plugins").data)["plugins"]}
+        assert plugins["pomodoro"]["mandatory"] is True
+        assert plugins["pomodoro"]["active"] is True
+        assert plugins["settings"]["mandatory"] is True
+        assert plugins["settings"]["active"] is True
+        assert plugins["todos"]["mandatory"] is False
+
+    def test_registry_is_mandatory(self):
+        assert plugin_registry.is_mandatory("extension", "pomodoro") is True
+        assert plugin_registry.is_mandatory("extension", "settings") is True
+        assert plugin_registry.is_mandatory("extension", "todos") is False
+
+    def test_cannot_disable_mandatory_plugin(self, client):
+        for pid in ("pomodoro", "settings"):
+            response = client.post(
+                "/api/plugins/toggle",
+                json={"plugin_id": pid, "plugin_type": "extension", "enable": False},
+            )
+            assert response.status_code == 403, f"{pid} disable should be forbidden"
+            # still active afterwards
+            plugins = {p["id"]: p for p in json.loads(client.get("/api/plugins").data)["plugins"]}
+            assert plugins[pid]["active"] is True
+
+    def test_optional_plugin_still_toggleable(self, client):
+        response = client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "todos", "plugin_type": "extension", "enable": False},
+        )
+        assert response.status_code == 200
+
+
 class TestClearInitialSync:
     """Tests for the clear-initial-sync endpoint."""
 

--- a/tests/test_mcp_plugin_gating.py
+++ b/tests/test_mcp_plugin_gating.py
@@ -60,16 +60,20 @@ def test_gating_is_per_plugin(caller_ctx):
         mcp_server._make_plugin_ctx("todos")()
 
 
-def test_registry_returns_id_registrar_pairs():
-    """get_mcp_tool_registrars yields (plugin_id, callable) for every plugin with a
-    registrar, so the MCP server can gate each per-user."""
+def test_registry_returns_id_registrar_mandatory_triples():
+    """get_mcp_tool_registrars yields (plugin_id, callable, mandatory) for every
+    plugin with a registrar, so the MCP server can register each with the right
+    gating — mandatory plugins ungated, optional plugins per-user."""
     import plugin_registry
 
-    pairs = plugin_registry.get_mcp_tool_registrars()
-    assert pairs, "expected at least the todos registrar"
-    for item in pairs:
-        assert isinstance(item, tuple) and len(item) == 2
-        pid, registrar = item
+    triples = plugin_registry.get_mcp_tool_registrars()
+    assert triples, "expected at least the pomodoro and todos registrars"
+    for item in triples:
+        assert isinstance(item, tuple) and len(item) == 3
+        pid, registrar, mandatory = item
         assert isinstance(pid, str)
         assert callable(registrar)
-    assert "todos" in {pid for pid, _ in pairs}
+        assert isinstance(mandatory, bool)
+    by_id = {pid: mandatory for pid, _registrar, mandatory in triples}
+    assert by_id.get("pomodoro") is True  # mandatory
+    assert by_id.get("todos") is False  # optional


### PR DESCRIPTION
## Summary

Unifies Acquacotta's feature model so **Pomodoro, Settings, and Todos are all first-class plugins** listed uniformly. Two are **mandatory** — always registered/enabled, non-toggleable, MCP tools always available — while Todos stays optional with the per-user enable/disable from spec 008.

Completes the plugin architecture started in 007 (per-user storage) and 008 (per-user optional plugins). See `specs/009-mandatory-plugins/spec.md`.

### Changes
- **`plugin_registry`**: `mandatory` flag on registration; `list_plugins` reports it and forces mandatory→active; `is_mandatory()`; `get_mcp_tool_registrars()` now returns `(id, registrar, mandatory)` triples.
- **Pomodoro/Settings as plugins**: `pomodoro_tools` gains `PLUGIN_METADATA` (mandatory) and registers in `app.py` + `mcp_server.py`; Settings registered as a mandatory metadata-only plugin. Removed the hardcoded `pomodoro_tools.register_mcp_tools` — Pomodoro's tools now flow through the same registrar path, **ungated** because mandatory.
- **`app.py`**: `/api/plugins/toggle` returns **403** for a mandatory plugin.
- **`index.html`**: mandatory rows render **checked + disabled** with a **"Required"** badge; `pluginEffectiveActive()` always-true for mandatory.

**No data-format change, no migration (FR-009).**

## Test plan
- [x] 220 unit tests pass; ruff (check + format) clean
- [x] Registry mandatory flag / always-active / `is_mandatory`; `/api/plugins` lists pomodoro/settings/todos with correct flags; mandatory toggle → 403; Todos toggle → 200; MCP registrars gate mandatory ungated + optional per-user
- [x] Web verified live: Plugins list shows all features; Pomodoro/Settings locked "Required"; Todos toggleable; Timer/Settings tabs unaffected
- [x] MCP server boots clean with Pomodoro registered ungated
- [ ] MCP end-to-end with a token — verify Pomodoro tools work regardless of Todos state (in prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)