### PR TITLE
fix: send credentials to the plugin endpoints so backend switching works

### DIFF
--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -396,6 +396,35 @@
     }
 
     /**
+     * Fetch a /api/plugins endpoint with the user's credentials attached.
+     *
+     * These endpoints resolve the per-user storage backend from the request
+     * credentials (spec 007). A bare fetch() leaves the server unable to tell who
+     * is asking, so it answers with the default backend and rejects the storage
+     * toggle as unauthenticated. Unlike authenticatedFetch this does not require a
+     * storage location: switching backends is exactly the moment the new backend
+     * has no location yet. Logged-out callers still get a valid generic answer,
+     * which is what the pre-login settings view renders.
+     */
+    function pluginFetch(url, options = {}) {
+        if (!storedCredentials) return fetch(url, options);
+
+        const payload = _buildCredentialsPayload();
+        const method = (options.method || 'GET').toUpperCase();
+        options.headers = options.headers || {};
+
+        if (method === 'GET' || method === 'DELETE') {
+            options.headers['X-Credentials'] = btoa(JSON.stringify(payload));
+        } else {
+            options.headers['Content-Type'] = 'application/json';
+            const body = options.body ? JSON.parse(options.body) : {};
+            body._credentials = payload;
+            options.body = JSON.stringify(body);
+        }
+        return fetch(url, options);
+    }
+
+    /**
      * Add to sync queue (with duplicate prevention)
      */
     async function addToSyncQueue(operation, store, recordId, data = null) {
@@ -775,7 +804,7 @@
 
             // Fetch active plugin info to know which location fields are required
             try {
-                const pluginRes = await fetch('/api/plugins');
+                const pluginRes = await pluginFetch('/api/plugins');
                 if (pluginRes.ok) {
                     const pluginData = await pluginRes.json();
                     cachedActivePlugin = pluginData.plugins.find(p => p.active && p.plugin_type === 'storage') || null;
@@ -1007,6 +1036,21 @@
 
         getActivePlugin: function() {
             return cachedActivePlugin;
+        },
+
+        /**
+         * Fetch a /api/plugins endpoint with the user's credentials attached.
+         *
+         * These endpoints resolve the per-user storage backend from the request
+         * credentials (spec 007). A bare fetch() leaves the server unable to tell
+         * who is asking, so it answers with the default backend and rejects the
+         * storage toggle as unauthenticated. Unlike authenticatedFetch this does
+         * not require a storage location: switching backends is exactly the moment
+         * the new backend has no location yet. Logged-out callers still get a valid
+         * generic answer, which is what the pre-login settings view renders.
+         */
+        pluginFetch: function(url, options = {}) {
+            return pluginFetch(url, options);
         },
 
         /**

--- a/templates/index.html
+++ b/templates/index.html
@@ -3870,7 +3870,7 @@
             const container = document.getElementById('plugins-list');
             const loading = document.getElementById('plugins-loading');
             try {
-                const resp = await fetch('/api/plugins');
+                const resp = await Storage.pluginFetch('/api/plugins');
                 if (!resp.ok) throw new Error('Failed to load plugins');
                 const data = await resp.json();
                 loading.style.display = 'none';
@@ -3964,14 +3964,25 @@
             const pluginType = checkbox.dataset.pluginType;
             const enable = checkbox.checked;
 
+            // Switching to pCloud isn't a preference the server can just record —
+            // it needs an access token that only the OAuth link produces. Send the
+            // user through it; its callback records the backend on the way back.
+            if (pluginId === 'json-pcloud' && enable && !(authStatus.logged_in && authStatus.pcloud_linked)) {
+                checkbox.checked = false;
+                loginPCloud();
+                return;
+            }
+
             try {
-                const resp = await fetch('/api/plugins/toggle', {
+                const resp = await Storage.pluginFetch('/api/plugins/toggle', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ plugin_id: pluginId, plugin_type: pluginType, enable }),
                 });
                 if (!resp.ok) {
                     checkbox.checked = !enable;
+                    const reason = await resp.json().then(d => d.error).catch(() => null);
+                    alert(reason || `Could not change ${pluginId} (HTTP ${resp.status}).`);
                     return;
                 }
                 const data = await resp.json();
@@ -3983,18 +3994,19 @@
                 settings[`plugin_state_${pluginId}`] = enable;
 
                 // Refresh plugin info and auth UI to reflect the new active plugin
-                activePluginInfo = await fetch('/api/plugins').then(r => r.json()).then(d =>
+                activePluginInfo = await Storage.pluginFetch('/api/plugins').then(r => r.json()).then(d =>
                     d.plugins.find(p => p.active && p.plugin_type === 'storage') || null
                 );
                 updateSyncCardVisibility(data.active_storage);
                 updateAuthUI();
                 loadPlugins();
-                fetch('/api/plugins').then(r => r.json()).then(d => updateExtensionTabs(d.plugins));
+                Storage.pluginFetch('/api/plugins').then(r => r.json()).then(d => updateExtensionTabs(d.plugins));
                 populateTypeDropdowns();
                 loadHistory();
                 loadWeeklyOverview();
             } catch (e) {
                 checkbox.checked = !enable;
+                alert(`Could not change ${pluginId}: ${e.message}`);
             }
         }
 
@@ -4246,7 +4258,7 @@
             // Query active plugins that contribute timer types
             _timerTypeProviders = [];
             try {
-                const pluginRes = await fetch('/api/plugins');
+                const pluginRes = await Storage.pluginFetch('/api/plugins');
                 const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
                 const timerTypePlugins = pluginData.plugins.filter(p => p.active && p.has_timer_types);
 
@@ -4598,7 +4610,7 @@
 
             // Todos row (if plugin active)
             try {
-                const pluginRes = await fetch('/api/plugins');
+                const pluginRes = await Storage.pluginFetch('/api/plugins');
                 const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
                 const todosActive = pluginData.plugins.find(p => p.id === 'todos' && p.active);
                 if (todosActive) {
@@ -4643,7 +4655,7 @@
             </div>`;
 
             try {
-                const pluginRes = await fetch('/api/plugins');
+                const pluginRes = await Storage.pluginFetch('/api/plugins');
                 const pluginData = pluginRes.ok ? await pluginRes.json() : { plugins: [] };
                 const todosActive = pluginData.plugins.find(p => p.id === 'todos' && p.active);
                 if (todosActive) {
@@ -6174,7 +6186,7 @@
             // to mutate shared server state on page load — that reconfigured the app for
             // every user. We just reflect the current user's choices in the UI.
             try {
-                const pluginData = await fetch('/api/plugins').then(r => r.json());
+                const pluginData = await Storage.pluginFetch('/api/plugins').then(r => r.json());
                 updateExtensionTabs(pluginData.plugins);
             } catch (e) { /* offline — use server defaults */ }
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -507,3 +507,52 @@ class TestPCloudBackendWiring:
         ):
             response = client.get("/auth/pcloud/callback?code=abc&state=forged")
         assert response.status_code == 400
+
+
+class TestPluginEndpointsResolvePerUser:
+    """The plugin endpoints identify the user from request credentials. Calling
+    them without credentials made every user look like a brand-new one, so the
+    UI always showed the default backend active and the storage toggle 401'd —
+    the whole reason a backend switch could not be completed from the UI."""
+
+    def _creds_header(self, email):
+        return base64.b64encode(json.dumps({"user_email": email}).encode()).decode()
+
+    def test_list_reports_the_callers_own_backend(self, client):
+        client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "json-pcloud", "plugin_type": "storage", "enable": True},
+            headers={"X-Credentials": self._creds_header("pc@example.com")},
+        )
+        response = client.get("/api/plugins", headers={"X-Credentials": self._creds_header("pc@example.com")})
+        data = json.loads(response.data)
+        assert data["active_storage"] == "json-pcloud"
+        pcloud = next(p for p in data["plugins"] if p["id"] == "json-pcloud")
+        drive = next(p for p in data["plugins"] if p["id"] == "json-google-drive")
+        assert pcloud["active"] is True
+        assert drive["active"] is False
+
+    def test_storage_toggle_succeeds_with_credentials(self, client):
+        response = client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "json-pcloud", "plugin_type": "storage", "enable": True},
+            headers={"X-Credentials": self._creds_header("switch@example.com")},
+        )
+        assert response.status_code == 200
+        assert json.loads(response.data)["active_storage"] == "json-pcloud"
+
+    def test_storage_toggle_without_credentials_is_rejected(self, client):
+        response = client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "json-pcloud", "plugin_type": "storage", "enable": True},
+        )
+        assert response.status_code == 401
+
+    def test_one_users_switch_does_not_move_another(self, client):
+        client.post(
+            "/api/plugins/toggle",
+            json={"plugin_id": "json-pcloud", "plugin_type": "storage", "enable": True},
+            headers={"X-Credentials": self._creds_header("alice@example.com")},
+        )
+        response = client.get("/api/plugins", headers={"X-Credentials": self._creds_header("bob@example.com")})
+        assert json.loads(response.data)["active_storage"] == app_module.DEFAULT_STORAGE_BACKEND


### PR DESCRIPTION
Fixes the report that "the Google Drive checkbox is stuck on and the pCloud checkbox won't check."

## Root cause — predates the pCloud plugin

The storage backend is a per-user choice the server resolves from the request credentials (spec 007). But every frontend call to `/api/plugins` and `/api/plugins/toggle` used a bare `fetch()` with no credentials attached, so the server could not tell who was asking:

- `GET /api/plugins` fell back to `DEFAULT_STORAGE_BACKEND` → **JSON on Google Drive rendered active for everyone**, regardless of their real choice.
- `POST /api/plugins/toggle` returned **401** for any storage plugin, and `togglePlugin` silently reverted the checkbox → **no storage backend could be selected from the UI at all.**

Reproduced against production before the fix:

```
$ curl -s https://acquacotta.crunchtools.com/api/plugins | jq -r .active_storage
json-google-drive          # regardless of caller

$ curl -s -X POST .../api/plugins/toggle -d '{"plugin_id":"json-pcloud",...}'
{"error":"Not authenticated"}   HTTP 401
```

Switching to Sheets was equally broken. pCloud was just the first backend switch anyone attempted since spec 007 landed.

## Fix

`pluginFetch()` in `storage.js` attaches credentials when present. Unlike `authenticatedFetch` it deliberately does **not** require a storage location — switching backends is precisely the moment the new backend has none yet — and it stays usable logged out, which the pre-login settings view renders. All 9 call sites converted.

Two UI fixes for the same report:

- A failed toggle now reports why instead of silently snapping back. The silence is why this looked like "the checkbox won't check" rather than an error.
- Toggling pCloud on now starts the OAuth link instead of recording a backend the browser has no token for. Linking *is* the switch — its callback already records the backend.

## Testing

- 4 new server tests pinning the contract: the list reports the caller's own backend, the toggle succeeds with credentials and 401s without, and one user's switch doesn't move another's.
- 273 tests pass; ruff 0.16.1 check + format clean; `node --check` on storage.js.

Note the new tests pin the **server** contract, which was already correct — the defect was client-side. They guard against the endpoints silently losing per-user resolution, but the client wiring itself is verified by manual retest in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RYAzzVJJqrsp6TkeRS4vX